### PR TITLE
Adding context switch

### DIFF
--- a/src/components/CreationCohort/DataList_Criteria.tsx
+++ b/src/components/CreationCohort/DataList_Criteria.tsx
@@ -12,7 +12,7 @@ import GhmForm from './DiagramView/components/LogicalOperator/components/Criteri
 import MedicationForm from './DiagramView/components/LogicalOperator/components/CriteriaRightPanel/MedicationForm'
 import BiologyForm from './DiagramView/components/LogicalOperator/components/CriteriaRightPanel/BiologyForm'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import { ODD_BIOLOGY, ODD_MEDICATION } from '../../constants'
 

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/DocumentsForm/DocumentsForm.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/DocumentsForm/DocumentsForm.tsx
@@ -25,7 +25,7 @@ import { InputSearchDocument } from 'components/Inputs'
 import useStyles from './styles'
 
 import { DocType, DocumentDataType, errorDetails, searchInputError } from 'types'
-import services from 'services/aphp'
+import services from 'services'
 import { useDebounce } from 'utils/debounce'
 
 type TestGeneratedFormProps = {

--- a/src/components/CreationCohort/DiagramView/components/PopulationCard/PopulationCard.tsx
+++ b/src/components/CreationCohort/DiagramView/components/PopulationCard/PopulationCard.tsx
@@ -16,7 +16,8 @@ import { MeState } from 'state/me'
 
 import { ScopeTreeRow } from 'types'
 import { getSelectedScopes, filterScopeTree } from 'utils/scopeTree'
-import servicesPerimeters from 'services/aphp/servicePerimeters'
+import services from 'services'
+const servicesPerimeters = services.perimeters
 
 import useStyles from './styles'
 

--- a/src/components/CreationCohort/Modals/ModalCreateNewRequest/ModalCreateNewRequest.tsx
+++ b/src/components/CreationCohort/Modals/ModalCreateNewRequest/ModalCreateNewRequest.tsx
@@ -16,7 +16,7 @@ import RequestForm from './components/RequestForm'
 import RequestList from './components/RequestList'
 
 import { RequestType } from 'types'
-import services from 'services/aphp'
+import services from 'services'
 
 import { useAppSelector, useAppDispatch } from 'state'
 import { ProjectState, fetchProjects } from 'state/project'

--- a/src/components/CreationCohort/Requeteur.tsx
+++ b/src/components/CreationCohort/Requeteur.tsx
@@ -19,7 +19,7 @@ import constructCriteriaList from './DataList_Criteria'
 import { getDataFromFetch } from 'utils/cohortCreation'
 
 import useStyles from './styles'
-import services from 'services/aphp'
+import services from 'services'
 
 const Requeteur = () => {
   const {

--- a/src/components/Dashboard/Documents/Documents.tsx
+++ b/src/components/Dashboard/Documents/Documents.tsx
@@ -12,7 +12,7 @@ import { ReactComponent as FilterList } from 'assets/icones/filter.svg'
 
 import { CohortComposition, DocumentFilters, Order, DTTB_ResultsType as ResultsType, searchInputError } from 'types'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import { buildDocumentFiltersChips } from 'utils/chips'
 

--- a/src/components/Dashboard/ExportModal/ExportModal.tsx
+++ b/src/components/Dashboard/ExportModal/ExportModal.tsx
@@ -32,7 +32,7 @@ import InfoIcon from '@material-ui/icons/Info'
 import useStyles from './styles'
 
 import export_table from './export_table'
-import services from 'services/aphp'
+import services from 'services'
 
 const initialState = {
   motif: '',

--- a/src/components/Dashboard/PatientList/PatientList.tsx
+++ b/src/components/Dashboard/PatientList/PatientList.tsx
@@ -13,7 +13,7 @@ import MasterChips from 'components/MasterChips/MasterChips'
 
 import PatientCharts from './components/PatientCharts'
 
-import services from 'services/aphp'
+import services from 'services'
 import { PatientGenderKind } from '@ahryman40k/ts-fhir-types/lib/R4'
 import {
   AgeRepartitionType,

--- a/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/src/components/DocumentViewer/DocumentViewer.tsx
@@ -13,7 +13,7 @@ import Typography from '@material-ui/core/Typography'
 
 import { Document, Page, pdfjs } from 'react-pdf'
 import { FHIR_API_URL } from '../../constants'
-import services from 'services/aphp'
+import services from 'services'
 
 import Watermark from 'assets/images/watermark_pseudo.svg'
 

--- a/src/components/Filters/MedicationFilters/MedicationFilters.tsx
+++ b/src/components/Filters/MedicationFilters/MedicationFilters.tsx
@@ -19,7 +19,7 @@ import { Autocomplete } from '@material-ui/lab'
 
 import ClearIcon from '@material-ui/icons/Clear'
 
-import services from 'services/aphp'
+import services from 'services'
 import { capitalizeFirstLetter } from 'utils/capitalize'
 
 import { MedicationsFilters } from 'types'

--- a/src/components/Filters/PMSIFilters/PMSIFilters.tsx
+++ b/src/components/Filters/PMSIFilters/PMSIFilters.tsx
@@ -19,7 +19,7 @@ import { Autocomplete } from '@material-ui/lab'
 
 import ClearIcon from '@material-ui/icons/Clear'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import { capitalizeFirstLetter } from 'utils/capitalize'
 

--- a/src/components/MyProjects/Modals/ModalShareRequest/ModalShareRequest.tsx
+++ b/src/components/MyProjects/Modals/ModalShareRequest/ModalShareRequest.tsx
@@ -10,7 +10,7 @@ import { RequestState } from 'state/request'
 
 import RequestShareForm from './components/RequestShareForm'
 import useStyles from './styles'
-import services from 'services/aphp'
+import services from 'services'
 
 const ERROR_TITLE = 'error_title'
 const ERROR_USER_SHARE_LIST = 'error_user_share_list'

--- a/src/components/Patient/PatientSidebar/PatientSidebar.tsx
+++ b/src/components/Patient/PatientSidebar/PatientSidebar.tsx
@@ -11,7 +11,7 @@ import PatientSidebarItem from './PatientSidebarItem/PatientSidebarItem'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 
 import { getAge } from 'utils/age'
-import services from 'services/aphp'
+import services from 'services'
 import { PatientGenderKind } from '@ahryman40k/ts-fhir-types/lib/R4'
 import { CohortPatient, PatientFilters as PatientFiltersType, SearchByTypes, Sort, VitalStatus } from 'types'
 

--- a/src/components/Patient/PatientTimeline/PatientTimeline.tsx
+++ b/src/components/Patient/PatientTimeline/PatientTimeline.tsx
@@ -25,7 +25,7 @@ import { capitalizeFirstLetter } from 'utils/capitalize'
 import { useAppDispatch } from 'state'
 import { fetchAllProcedures } from 'state/patient'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import useStyles from './styles'
 

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -40,7 +40,7 @@ import { favoriteExploredCohort } from 'state/exploredCohort'
 import { deleteCohort, fetchCohorts as fetchCohortsList, setSelectedCohort } from 'state/cohort'
 import { MeState } from 'state/me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import displayDigit from 'utils/displayDigit'
 

--- a/src/components/Welcome/PatientsCard/PatientsCard.jsx
+++ b/src/components/Welcome/PatientsCard/PatientsCard.jsx
@@ -7,7 +7,7 @@ import useStyles from './styles'
 
 import Typography from '@material-ui/core/Typography'
 import CircularProgress from '@material-ui/core/CircularProgress'
-import services from 'services/aphp'
+import services from 'services'
 
 import displayDigit from 'utils/displayDigit'
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,8 @@ export let BOOLEANTRUE = 'true'
 export const ACCES_TOKEN = 'access'
 export const REFRESH_TOKEN = 'refresh'
 
+export const CONTEXT = process.env.REACT_APP_CONTEXT ?? 'aphp'
+
 export const BACK_API_URL =
   process.env.NODE_ENV !== 'development' ? '{REACT_APP_BACK_API_URL}' : process.env.REACT_APP_BACK_API_URL
 export const REQUEST_API_URL =

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,13 @@
+import { CONTEXT } from './../constants'
+import servicesAphp, { IServiceAphp } from './aphp'
+
+let services: IServiceAphp = servicesAphp
+switch (CONTEXT) {
+  case 'aphp':
+    services = servicesAphp
+    break
+  default:
+    break
+}
+
+export default services

--- a/src/state/biology.ts
+++ b/src/state/biology.ts
@@ -3,7 +3,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { RootState } from 'state'
 import { login, logout } from 'state/me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type BiologyListType = {
   id: string

--- a/src/state/cohort.ts
+++ b/src/state/cohort.ts
@@ -3,7 +3,7 @@ import { RootState } from 'state'
 import { Cohort, CohortFilters, Sort } from 'types'
 
 import { logout, login } from './me'
-import services from 'services/aphp'
+import services from 'services'
 
 export type CohortState = {
   loading: boolean

--- a/src/state/cohortCreation.ts
+++ b/src/state/cohortCreation.ts
@@ -15,7 +15,7 @@ import { logout, login } from './me'
 import { addRequest, deleteRequest } from './request'
 import { deleteProject } from './project'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type CohortCreationState = {
   loading: boolean

--- a/src/state/exploredCohort.ts
+++ b/src/state/exploredCohort.ts
@@ -6,7 +6,7 @@ import { RootState } from 'state'
 
 import { ODD_EXPORT } from '../constants'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type ExploredCohortState = {
   importedPatients: any[]

--- a/src/state/me.ts
+++ b/src/state/me.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit'
 import { RootState } from 'state'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type MeState = null | {
   id: string

--- a/src/state/medication.ts
+++ b/src/state/medication.ts
@@ -3,7 +3,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { RootState } from 'state'
 import { login, logout } from 'state/me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type MedicationListType = {
   id: string

--- a/src/state/patient.ts
+++ b/src/state/patient.ts
@@ -26,7 +26,7 @@ import {
 
 import { logout } from './me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type PatientState = null | {
   loading: boolean

--- a/src/state/pmsi.ts
+++ b/src/state/pmsi.ts
@@ -3,7 +3,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { RootState } from 'state'
 import { login, logout } from 'state/me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type PmsiListType = {
   id: string

--- a/src/state/project.ts
+++ b/src/state/project.ts
@@ -4,7 +4,7 @@ import { ProjectType } from 'types'
 
 import { logout, login } from './me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type ProjectState = {
   loading: boolean

--- a/src/state/request.ts
+++ b/src/state/request.ts
@@ -4,7 +4,7 @@ import { RequestType } from 'types'
 
 import { logout, login } from './me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 export type RequestState = {
   loading: boolean

--- a/src/state/scope.ts
+++ b/src/state/scope.ts
@@ -3,7 +3,7 @@ import { RootState } from 'state'
 
 import { logout, login } from './me'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import { ScopeTreeRow } from 'types'
 

--- a/src/utils/cohortCreation.ts
+++ b/src/utils/cohortCreation.ts
@@ -1,6 +1,6 @@
 import moment from 'moment'
 
-import services from 'services/aphp'
+import services from 'services'
 import { ScopeTreeRow, SelectedCriteriaType, CriteriaGroupType, TemporalConstraintsType, DocType } from 'types'
 
 import { docTypes } from 'assets/docTypes.json'

--- a/src/views/Contact/Contact.tsx
+++ b/src/views/Contact/Contact.tsx
@@ -15,7 +15,7 @@ import {
 } from '@material-ui/core'
 import { Alert } from '@material-ui/lab'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import useStyles from './styles'
 

--- a/src/views/Login/Login.jsx
+++ b/src/views/Login/Login.jsx
@@ -29,7 +29,7 @@ import { useAppDispatch } from 'state'
 import { login as loginAction } from 'state/me'
 import { ACCES_TOKEN, REFRESH_TOKEN } from '../../constants'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import useStyles from './styles'
 

--- a/src/views/SearchPatient/SearchPatient.tsx
+++ b/src/views/SearchPatient/SearchPatient.tsx
@@ -8,7 +8,7 @@ import { CircularProgress, Grid, Typography } from '@material-ui/core'
 import PatientSearchBar from 'components/Inputs/PatientSearchBar/PatientSearchBar'
 import DataTablePatient from 'components/DataTable/DataTablePatient'
 
-import services from 'services/aphp'
+import services from 'services'
 
 import { IPatient } from '@ahryman40k/ts-fhir-types/lib/R4'
 import { SearchByTypes, Order } from 'types'


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #693  by @oxabz

## Description
Adds the context switch to allow for other context

## Technical details
- The `CONTEXT` constant doesn't use the placeholder string method to avoid tree shaking of the context switch.
- serviceProvider isn't included into the service interface 
