### PR TITLE
fix: logout first then clear local storage

### DIFF
--- a/src/services/aphp/servicePractitioner.ts
+++ b/src/services/aphp/servicePractitioner.ts
@@ -76,8 +76,8 @@ const servicePractitioner: IServicePractitioner = {
   },
 
   logout: async () => {
-    localStorage.clear()
     await apiBackend.post(`/accounts/logout/`)
+    localStorage.clear()
   },
 
   maintenance: async () => {


### PR DESCRIPTION
## Fixes
logout first then clear local storage so not to lose the `authorizationmethod` value. Otherwise the logout request is **always** sent to the backend with a `authorizationmethod` set to JWT
