### PR TITLE
fix links of partners in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ A contributing guide will be published soon.
 ## Partners
 
 * AP-HP Clinical Data Warehouse
-* Arkhn : arkhn.org
-* Akimed : akimed.io
+* Arkhn : [arkhn.org](https://arkhn.org/)
+* Akimed : [www.akimed.io](https://www.akimed.io/)
 
 ## Contributors
 


### PR DESCRIPTION
## Fixes
Fixes #821 by @thiswillbeyourgithub

## Description
Make the url strings working links and add the missing 'www'

## Technical details
Not relevant.

## Tests
1. Click on the links
2. Check that the new tab is not 404
