### PR TITLE
fix: add new type and fix attribute name

### DIFF
--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -10,7 +10,8 @@ import {
   HierarchyElementWithSystem,
   IScope,
   Back_API_Response,
-  Cohort
+  Cohort,
+  DataRights
 } from 'types'
 
 import { FHIR_Bundle_Response } from 'types'
@@ -980,8 +981,8 @@ export const fetchAccessExpirations: (
   return response
 }
 
-export const fetchPerimeterAccesses = async (perimeter: string) => {
-  const response = await apiBackend.get(`accesses/accesses/my-data-rights/?perimeters_ids=${perimeter}`)
+export const fetchPerimeterAccesses = async (perimeter: string): Promise<AxiosResponse<DataRights[]>> => {
+  const response = await apiBackend.get<DataRights[]>(`accesses/accesses/my-data-rights/?perimeters_ids=${perimeter}`)
   return response
 }
 

--- a/src/services/aphp/servicePerimeters.ts
+++ b/src/services/aphp/servicePerimeters.ts
@@ -3,6 +3,7 @@ import {
   AccessExpirationsProps,
   ChartCode,
   CohortData,
+  DataRights,
   ScopeElement,
   ScopePage,
   ScopeTreeRow,
@@ -182,7 +183,7 @@ const servicesPerimeters: IServicePerimeters = {
       .join(',')
 
     const rightResponse = await fetchPerimeterAccesses(perimetersIds)
-    const rightsData = (rightResponse.data as any[]) ?? []
+    const rightsData = (rightResponse.data as DataRights[]) ?? []
 
     let allowSearchIpp = false
 
@@ -410,10 +411,10 @@ const servicesPerimeters: IServicePerimeters = {
     const perimetersIds = perimeters.map((perimeter) => perimeter.id).join(',')
 
     const rightResponse = await fetchPerimeterAccesses(perimetersIds)
-    const rightsData = (rightResponse.data as any[]) ?? []
+    const rightsData = (rightResponse.data as DataRights[]) ?? []
 
     return perimeters.map((perimeter) => {
-      const foundRight = rightsData.find((rightData) => rightData.care_site_id === +(perimeter.id ?? '0'))
+      const foundRight = rightsData.find((rightData) => rightData.perimeter_id === +(perimeter.id ?? '0'))
 
       return {
         ...perimeter,

--- a/src/services/aphp/servicePerimeters.ts
+++ b/src/services/aphp/servicePerimeters.ts
@@ -3,7 +3,6 @@ import {
   AccessExpirationsProps,
   ChartCode,
   CohortData,
-  DataRights,
   ScopeElement,
   ScopePage,
   ScopeTreeRow,

--- a/src/services/aphp/servicePerimeters.ts
+++ b/src/services/aphp/servicePerimeters.ts
@@ -411,7 +411,7 @@ const servicesPerimeters: IServicePerimeters = {
     const perimetersIds = perimeters.map((perimeter) => perimeter.id).join(',')
 
     const rightResponse = await fetchPerimeterAccesses(perimetersIds)
-    const rightsData = (rightResponse.data as DataRights[]) ?? []
+    const rightsData = rightResponse.data ?? []
 
     return perimeters.map((perimeter) => {
       const foundRight = rightsData.find((rightData) => rightData.perimeter_id === +(perimeter.id ?? '0'))

--- a/src/services/aphp/servicePerimeters.ts
+++ b/src/services/aphp/servicePerimeters.ts
@@ -183,7 +183,7 @@ const servicesPerimeters: IServicePerimeters = {
       .join(',')
 
     const rightResponse = await fetchPerimeterAccesses(perimetersIds)
-    const rightsData = (rightResponse.data as DataRights[]) ?? []
+    const rightsData = rightResponse.data ?? []
 
     let allowSearchIpp = false
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -740,6 +740,19 @@ export type GroupRights = {
   read_patient_pseudo?: boolean
 }
 
+export type DataRights = {
+  user_id: string
+  perimeter_id: number
+  right_read_patient_nominative: boolean
+  right_read_patient_pseudonymized: boolean
+  right_export_csv_nominative: boolean
+  right_export_csv_pseudonymized: boolean
+  right_export_jupyter_nominative: boolean
+  right_export_jupyter_pseudonymized: boolean
+  right_search_opposed_patients: boolean
+  right_search_patients_by_ipp: boolean
+}
+
 export type ScopeType =
   | 'AP-HP'
   | 'Groupe hospitalier (GH)'


### PR DESCRIPTION
## Fixes
replace `care_site_id` by `perimeter_id` to match the backend's response when calling `GET /accesses/accesses/my-data-rights/?perimeters_ids=xxxxx,yyyy,zzzz`

## Description
this bug causes the user to have `pseudonymized` access when exploring a perimeter even if he has `nominative` access

## Technical details
added new type `DataRights` to enhance type checking

## Tests
None