### PR TITLE
2873#harmonisation recherche correction

### DIFF
--- a/src/utils/valueSets.ts
+++ b/src/utils/valueSets.ts
@@ -1,8 +1,9 @@
 import { getConfig } from 'config'
 import { getReferences } from 'data/valueSets'
-import { HIERARCHY_ROOT } from 'services/aphp/serviceValueSets'
-import { Hierarchy } from 'types/hierarchy'
+import { HIERARCHY_ROOT, getChildrenFromCodes } from 'services/aphp/serviceValueSets'
+import { Codes, Hierarchy } from 'types/hierarchy'
 import { LabelObject } from 'types/searchCriterias'
+import { FhirItem } from 'types/valueSet'
 
 export const getValueSetsFromSystems = (systems: string[]) => {
   return getReferences(getConfig()).filter((reference) => systems.includes(reference.url))
@@ -36,4 +37,15 @@ export const getFullLabelFromCode = (code: LabelObject) => {
 export const getLabelFromSystem = (system: string) => {
   const isFound = getValueSetsFromSystems([system])?.[0]
   return isFound?.label || ''
+}
+
+export const checkIsLeaf = async <T>(codes: Hierarchy<T>[], cache: Codes<Hierarchy<T>>): Promise<boolean> => {
+  const children = (codes?.[0]?.inferior_levels_ids || '').split(',')
+  if (codes.length !== 1 || codes?.[0]?.id === HIERARCHY_ROOT || children.length > 1) return false
+  if (!children[0]) return true
+  const code = codes[0]
+  const found = cache.get(code.system)?.get(children[0])
+  let childCode: Hierarchy<FhirItem>[] = found ? [found] : []
+  if (!childCode.length) childCode = (await getChildrenFromCodes(code.system, children)).results
+  return checkIsLeaf(childCode, cache)
 }


### PR DESCRIPTION
## Fixes
Correction sur la "Recherche par Valeur" qui ne s'affichait pas quand un code feuille enfant était sélectionné, car "caché" au sein d'un chapitre supérieur (seul enfant)
