### PR TITLE
refactor: update login URL

### DIFF
--- a/src/services/aphp/servicePractitioner.ts
+++ b/src/services/aphp/servicePractitioner.ts
@@ -49,7 +49,7 @@ const servicePractitioner: IServicePractitioner = {
   authenticateWithCode: async (authCode: string): Promise<AxiosResponse<Authentication> | AxiosError> => {
     try {
       return await apiBackend.post<Authentication>(
-        `/auth/oidc/login`,
+        `/auth/login/`,
         {
           auth_code: authCode,
           redirect_uri: getConfig().system.oidc?.redirectUri


### PR DESCRIPTION
now both login via OIDC and JWT are using the same endpoint `/auth/login/`