### PR TITLE
feat(filters): flag identifying filters

### DIFF
--- a/src/config.tsx
+++ b/src/config.tsx
@@ -19,6 +19,7 @@ export type AppConfig = {
     cohort: {
       enabled: boolean
       shortCohortLimit: number
+      identifyingFields: string[]
     }
     diagnosticReport: {
       enabled: boolean
@@ -218,7 +219,16 @@ let config: AppConfig = {
   features: {
     cohort: {
       enabled: true,
-      shortCohortLimit: 2000
+      shortCohortLimit: 2000,
+      identifyingFields: [
+        'family',
+        'given',
+        'identifier',
+        'age-day',
+        'subject.identifier',
+        'encounter.identifier',
+        'onlyPdfAvailable'
+      ]
     },
     diagnosticReport: {
       enabled: false,

--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -366,13 +366,15 @@ export const fetchDocumentReferenceContent = async (docId: string): FHIR_API_Pro
 export const postFilters = async (
   fhir_resource: ResourceType,
   name: string,
-  filter: string
+  filter: string,
+  identifying: boolean
 ): Promise<AxiosResponse<SavedFilter>> => {
   const res = await apiBackend.post('/cohort/fhir-filters/', {
     fhir_resource,
     fhir_version: '4.0',
     name,
-    filter
+    filter,
+    identifying
   })
   if (res instanceof AxiosError) throw "Le filtre n'a pas pu être sauvegardé."
   return res

--- a/src/utils/fhirFilterParser/index.ts
+++ b/src/utils/fhirFilterParser/index.ts
@@ -2,6 +2,7 @@ import { CharStreams, CommonTokenStream } from 'antlr4'
 import FilterLanguageLexer from './lib/FilterLanguageLexer'
 import FilterLanguageParser, { ExpressionContext, ParamExpContext } from './lib/FilterLanguageParser'
 import FilterLanguageVisitor from './lib/FilterLanguageVisitor'
+import { getConfig } from 'config'
 
 export type FhirFilterValue = {
   operator?: string
@@ -89,6 +90,19 @@ export const extractFilterParams = (filterStr: string, options?: ExtractionOptio
     return extractParams(expression, options)
   }
   return undefined
+}
+
+export const isIdentifyingFilter = (filterStr: string): boolean => {
+  // need to load appConfig
+  const identifyingFields = getConfig().features.cohort.identifyingFields
+  const criteria = filterStr.split('&')
+  for (const c of criteria) {
+    const key = c.split('=')[0]
+    if (identifyingFields.includes(key)) {
+      return true
+    }
+  }
+  return false
 }
 
 export default extractFilterParams


### PR DESCRIPTION
## Adds
A new attribute `identifying` is added to the payload when saving a filter.

## Description
if a filter contains at least one of the keys tagged as identifiers (family, given,...), the filter as a whole is tagged as identifying and may be applied only in nominative mode