### PR TITLE
fix(SearchValueSets): add error msg for missing values in 'search' op…

### DIFF
--- a/src/components/Dashboard/BiologyList/index.tsx
+++ b/src/components/Dashboard/BiologyList/index.tsx
@@ -77,7 +77,6 @@ const BiologyList = ({ deidentified }: BiologyListProps) => {
     },
     { changeOrderBy, changeSearchInput, addFilters, removeFilter, addSearchCriterias }
   ] = useSearchCriterias(initBioSearchCriterias)
-  console.log('test filters', filters)
   const filtersAsArray = useMemo(
     () =>
       selectFiltersAsArray({

--- a/src/components/SearchValueSet/index.tsx
+++ b/src/components/SearchValueSet/index.tsx
@@ -11,6 +11,8 @@ import { Displayer } from 'components/ui/Displayer/styles'
 import ClearIcon from '@mui/icons-material/Clear'
 import { Hierarchy, SearchMode, SearchModeLabel } from 'types/hierarchy'
 import { cleanNode } from 'utils/hierarchy'
+import { useAppDispatch } from 'state'
+import { setMessage } from 'state/message'
 
 type SearchValueSetProps = {
   references: Reference[]
@@ -19,6 +21,7 @@ type SearchValueSetProps = {
 }
 
 const SearchValueSet = ({ references, selectedNodes, onSelect }: SearchValueSetProps) => {
+  const dispatch = useAppDispatch()
   const {
     mode,
     searchInput,
@@ -28,7 +31,7 @@ const SearchValueSet = ({ references, selectedNodes, onSelect }: SearchValueSetP
     isSelectionDisabled,
     loadingStatus,
     parameters: { refs, onChangeReferences, onChangeSearchInput, onChangePage },
-    hierarchy: { exploration, research, selectAllStatus, expand, select, selectAll }
+    hierarchy: { exploration, research, selectAllStatus, hasError, expand, select, selectAll }
   } = useSearchValueSet(references, selectedNodes)
 
   const tabs: TabType<SearchMode, SearchModeLabel>[] = [
@@ -39,6 +42,17 @@ const SearchValueSet = ({ references, selectedNodes, onSelect }: SearchValueSetP
   useEffect(() => {
     onSelect(selectedCodes.map((e) => cleanNode(e)))
   }, [selectedCodes])
+
+  useEffect(() => {
+    if (hasError)
+      dispatch(
+        setMessage({
+          type: 'error',
+          content: `Tous les codes n'ont pas été récupérés. Votre recherche peut être incomplète. Si l'erreur persiste, merci
+              de contacter l'adresse support : id.recherche.support.dsn@aphp.fr'`
+        })
+      )
+  }, [hasError, research, dispatch])
 
   return (
     <Grid

--- a/src/hooks/hierarchy/useHierarchy.ts
+++ b/src/hooks/hierarchy/useHierarchy.ts
@@ -43,6 +43,7 @@ export const useHierarchy = <T>(
     search: LoadingStatus.SUCCESS,
     expand: LoadingStatus.SUCCESS
   })
+  const [hasError, setHasError] = useState(false)
 
   useEffect(() => {
     latestCodes.current = codes
@@ -106,10 +107,13 @@ export const useHierarchy = <T>(
     id?: string
   ) => {
     const { display, count } = await search(fetchSearch)
+    const cleaned = display.filter((e) => e)
+    if (display.length !== cleaned.length) setHasError(true)
+    else setHasError(false)
     if (mode == SearchMode.EXPLORATION && id) {
       const currentHierarchy = hierarchies.get(id) || DEFAULT_HIERARCHY_INFO
-      setHierarchies(replaceInMap(id, { ...currentHierarchy, tree: display, page }, hierarchies))
-    } else setSearchResults({ tree: display, count, page, system: '' })
+      setHierarchies(replaceInMap(id, { ...currentHierarchy, tree: cleaned, page }, hierarchies))
+    } else setSearchResults({ tree: cleaned, count, page, system: '' })
   }
 
   const select = (nodes: Hierarchy<T>[], toAdd: boolean, mode: SearchMode.EXPLORATION | SearchMode.RESEARCH) => {
@@ -167,6 +171,7 @@ export const useHierarchy = <T>(
     searchResults,
     selectedCodes,
     loadingStatus,
+    hasError,
     initTrees,
     select,
     selectAll,

--- a/src/hooks/valueSet/useSearchValueSet.ts
+++ b/src/hooks/valueSet/useSearchValueSet.ts
@@ -41,8 +41,18 @@ export const useSearchValueSet = (references: Reference[], selectedNodes: Hierar
 
   const codes = useAppSelector((state) => selectValueSetCodes(state, urls))
 
-  const { hierarchies, searchResults, selectedCodes, loadingStatus, initTrees, fetchMore, expand, select, selectAll } =
-    useHierarchy(selectedNodes, codes, handleSaveCodes, fetchChildren)
+  const {
+    hierarchies,
+    searchResults,
+    selectedCodes,
+    loadingStatus,
+    hasError,
+    initTrees,
+    fetchMore,
+    expand,
+    select,
+    selectAll
+  } = useHierarchy(selectedNodes, codes, handleSaveCodes, fetchChildren)
 
   const currentHierarchy = useMemo(() => {
     const ref = explorationParameters.options.references.find((ref) => ref.checked)
@@ -177,6 +187,7 @@ export const useSearchValueSet = (references: Reference[], selectedNodes: Hierar
       onChangeReferences: handleChangeReferences
     },
     hierarchy: {
+      hasError,
       exploration: currentHierarchy,
       research: searchResults,
       selectAllStatus,


### PR DESCRIPTION
## Fixes
L'interface crash lorsqu'il y a des éléments dont on ne retrouve pas le chemin. Cela n'est pas censé se produire sauf erreur côté Fhir donc gestion de l'interface pour que l’utilisateur puisse continuer à utiliser l'appli, tout en affichant un msg d'erreur afin de nous avertir.

