### PR TITLE
fix: update legal mention text - Ref gestion-de-projet#3163

### DIFF
--- a/src/views/Login/Login.tsx
+++ b/src/views/Login/Login.tsx
@@ -88,19 +88,27 @@ const LegalMentionDialog = ({ open, setOpen }: LegalMentionDialogProps) => {
       <DialogTitle>Mention légale</DialogTitle>
       <DialogContent>
         <DialogContentText align="justify">
-          L’usage de Cohort360 est soumis au respect des règles d’accès aux données de santé définies par la Commission
-          Médicale d’Etablissement de l’AP-HP disponibles à l’adresse recherche-innovation.aphp.fr.
+          L'usage de Cohort360 est soumis au respect des règles d'accès aux données de santé définies par la Commission
+          Médicale d'Etablissement de l'AP-HP disponibles à l'adresse recherche-innovation.aphp.fr.
         </DialogContentText>
-        <DialogContentText>
-          En appuyant sur le bouton « OK », vous acceptez ces conditions d’utilisation. Les données relatives à votre
-          connexion et à vos actions sur l’application (date, heure, type d’action), sont enregistrées et traitées pour
-          des finalités de sécurité du système d’information et afin de réaliser des statistiques d’utilisation de
-          l’application.
+        <DialogContentText align="justify">
+          L'usage de Cohort360 est également soumis au respect des règles d'utilisation acceptées par l'utilisateur au
+          moment de sa formation.
         </DialogContentText>
-        <DialogContentText>
-          Elles sont destinées à l’équipe projet de la DSI et sont conservées dans des fichiers de logs pendant 3 ans.
-          Vous pouvez exercer votre droit d’accès et de rectification aux informations qui vous concernent, en écrivant
-          à la déléguée à la protection des données de l’AP-HP à l’adresse protection.donnees.dsi@aphp.fr.
+        <DialogContentText align="justify">
+          En appuyant sur le bouton « OK », vous acceptez ces conditions d'utilisation. Les données relatives à votre
+          connexion et à vos actions sur l'application (date, heure, type d'action, APH, nom, prénom, mail, périmètre
+          d'habilitation), sont enregistrées et traitées pour des finalités de sécurité du système d'information et afin
+          de réaliser des statistiques d'utilisation de l'application.
+        </DialogContentText>
+        <DialogContentText align="justify">
+          Ces données sont conservées pendant la durée strictement nécessaire à leur finalité. Vous pouvez exercer votre
+          droit d'accès et de rectification aux informations qui vous concernent, en écrivant à la déléguée à la
+          protection des données de l'AP-HP à l'adresse <Link href="mailto:dpo@aphp.fr">dpo@aphp.fr</Link>.
+        </DialogContentText>
+        <DialogContentText align="justify">
+          Pour toute autre question, contactez l'équipe support :{' '}
+          <Link href="mailto:id.recherche.support.dsn@aphp.fr">id.recherche.support.dsn@aphp.fr</Link>.
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/src/views/Login/Login.tsx
+++ b/src/views/Login/Login.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom'
 import localforage from 'localforage'
 import {
   Alert,
+  Box,
   Button,
   CircularProgress,
   Dialog,
@@ -85,31 +86,33 @@ const LegalMentionDialog = ({ open, setOpen }: LegalMentionDialogProps) => {
 
   return (
     <Dialog open={open} onClose={_setOpen}>
-      <DialogTitle>Mention légale</DialogTitle>
+      <DialogTitle>Mentions légales</DialogTitle>
       <DialogContent>
-        <DialogContentText align="justify">
-          L'usage de Cohort360 est soumis au respect des règles d'accès aux données de santé définies par la Commission
-          Médicale d'Etablissement de l'AP-HP disponibles à l'adresse recherche-innovation.aphp.fr.
-        </DialogContentText>
-        <DialogContentText align="justify">
-          L'usage de Cohort360 est également soumis au respect des règles d'utilisation acceptées par l'utilisateur au
-          moment de sa formation.
-        </DialogContentText>
-        <DialogContentText align="justify">
-          En appuyant sur le bouton « OK », vous acceptez ces conditions d'utilisation. Les données relatives à votre
-          connexion et à vos actions sur l'application (date, heure, type d'action, APH, nom, prénom, mail, périmètre
-          d'habilitation), sont enregistrées et traitées pour des finalités de sécurité du système d'information et afin
-          de réaliser des statistiques d'utilisation de l'application.
-        </DialogContentText>
-        <DialogContentText align="justify">
-          Ces données sont conservées pendant la durée strictement nécessaire à leur finalité. Vous pouvez exercer votre
-          droit d'accès et de rectification aux informations qui vous concernent, en écrivant à la déléguée à la
-          protection des données de l'AP-HP à l'adresse <Link href="mailto:dpo@aphp.fr">dpo@aphp.fr</Link>.
-        </DialogContentText>
-        <DialogContentText align="justify">
-          Pour toute autre question, contactez l'équipe support :{' '}
-          <Link href="mailto:id.recherche.support.dsn@aphp.fr">id.recherche.support.dsn@aphp.fr</Link>.
-        </DialogContentText>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <DialogContentText align="justify">
+            L'usage de Cohort360 est soumis au respect des règles d'accès aux données de santé définies par la
+            Commission Médicale d'Etablissement de l'AP-HP disponibles à l'adresse recherche-innovation.aphp.fr.
+          </DialogContentText>
+          <DialogContentText align="justify">
+            L'usage de Cohort360 est également soumis au respect des règles d'utilisation acceptées par l'utilisateur au
+            moment de sa formation.
+          </DialogContentText>
+          <DialogContentText align="justify">
+            En appuyant sur le bouton « OK », vous acceptez ces conditions d'utilisation. Les données relatives à votre
+            connexion et à vos actions sur l'application (date, heure, type d'action, APH, nom, prénom, mail, périmètre
+            d'habilitation), sont enregistrées et traitées pour des finalités de sécurité du système d'information et
+            afin de réaliser des statistiques d'utilisation de l'application.
+          </DialogContentText>
+          <DialogContentText align="justify">
+            Ces données sont conservées pendant la durée strictement nécessaire à leur finalité. Vous pouvez exercer
+            votre droit d'accès et de rectification aux informations qui vous concernent, en écrivant à la déléguée à la
+            protection des données de l'AP-HP à l'adresse <Link href="mailto:dpo@aphp.fr">dpo@aphp.fr</Link>.
+          </DialogContentText>
+          <DialogContentText align="justify">
+            Pour toute autre question, contactez l'équipe support :{' '}
+            <Link href="mailto:id.recherche.support.dsn@aphp.fr">id.recherche.support.dsn@aphp.fr</Link>.
+          </DialogContentText>
+        </Box>
       </DialogContent>
       <DialogActions>
         <Button onClick={() => setOpen(false)}>OK</Button>
@@ -410,7 +413,7 @@ const Login = () => {
 
             <Typography align="center">
               <Link href="#" onClick={() => setOpen(true)} underline="hover">
-                En vous connectant, vous acceptez la mention légale.
+                En vous connectant, vous acceptez les mentions légales.
               </Link>
             </Typography>
           </Grid>


### PR DESCRIPTION
## Description

Update the legal notice dialog ("Mention légale") with the new text as requested in GitLab issue [gestion-de-projet#3163](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/issues/3163).

## Changes

The legal mention text has been updated according to the requirements:

### Before
- Only mentioned compliance with CME health data access rules
- Data collected: date, time, action type
- Data retained for 3 years in DSI log files
- Contact: protection.donnees.dsi@aphp.fr

### After  
- Mentions compliance with CME health data access rules
- **New**: Also mentions compliance with usage rules accepted during user training
- Data collected: date, time, action type, **APH, name, first name, email, authorization scope**
- Data retained for the **strictly necessary duration** for its purpose
- DPO contact: **dpo@aphp.fr**
- **New**: Support contact: **id.recherche.support.dsn@aphp.fr**
- Added `align="justify"` to all paragraphs for better readability

## Verification

1. Start the application locally
2. Go to the login page
3. Click on "En vous connectant, vous acceptez la mention légale" link
4. Verify the legal mention dialog displays the updated text

## Screenshots

N/A - Text-only change

---
**Fixes**: [gestion-de-projet#3163](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/issues/3163)