### PR TITLE
fix(export): disable note onefile

### DIFF
--- a/src/pages/ExportRequest/components/ExportTable/index.tsx
+++ b/src/pages/ExportRequest/components/ExportTable/index.tsx
@@ -139,6 +139,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
     if (exportTable.name === 'person') return true
     if (count === 0) return true
     if (oneFile && !isCompatibleTable(exportTable.name)) return true
+    if (oneFile && exportTable.name === 'note') return true
     return false
   }
 


### PR DESCRIPTION
## Fixes

Fixes [#3189](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3189)

## Description
The table "note" is disabled for onefile export

