### PR TITLE
chore(proxy): add development proxy configuration and example environment file

### DIFF
--- a/.env.dev-proxy.example
+++ b/.env.dev-proxy.example
@@ -1,0 +1,19 @@
+# Proxy Vite en dev — copier les lignes utiles dans `.env` (voir vite-dev-proxy.ts).
+
+# --- Stack locale typique : back Docker (hôte 8000) + FhirApi sur l’hôte (8080)
+VITE_DEV_PROXY_BACK=http://127.0.0.1:8000
+VITE_DEV_PROXY_FHIR=http://127.0.0.1:8080
+
+# /api/request : si absent, même cible que VITE_DEV_PROXY_FHIR. Pour désactiver : - ou off
+# VITE_DEV_PROXY_REQUEST=-
+
+# Portail : sans variable, c’est déjà la même cible que BACK. À n’utiliser que si le portail est ailleurs que le back.
+# VITE_DEV_PROXY_PORTAIL=http://127.0.0.1:8000
+
+# --- Hybride (front local, APIs distantes) — certificats non reconnus par Node : SECURE=false
+# VITE_DEV_PROXY_REQUEST=https://fhir-r4-develop-ext-k8s.eds.aphp.fr
+# VITE_DEV_PROXY_DATAMODEL=https://data-models-api-dev-ext-k8s.eds.aphp.fr
+# VITE_DEV_PROXY_SECURE=false
+
+# FhirApi en mode « attend OIDC » (header authorizationMethod) — inutile si tu passes le Bearer Django + JWT_SIGNING_KEY alignée
+# VITE_DEV_PROXY_FHIR_AUTH_METHOD=OIDC

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 # Cohort360 specific
 .env*
 !.env.example
+!.env.dev-proxy.example
 .mp4
 public/config.*.json
 *storybook.log

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This will generate files in the `build` directory that can be exposed via a web 
 
 An example configuration with Nginx can be found [here](.templates/nginx.conf)
 
+#### Dev server (`npm run start`) — API proxy without Nginx
+
+See [`.env.dev-proxy.example`](.env.dev-proxy.example) and [`vite-dev-proxy.ts`](vite-dev-proxy.ts). Use **`http://localhost:3000`** in the browser so relative API paths (`/api/back`, etc.) hit the Vite proxy.
+
 ## CI
 
 A [gitlab-ci.yml](.templates/.gitlab-ci.yml) is available in the `.templates` folder, alongside

--- a/vite-dev-proxy.ts
+++ b/vite-dev-proxy.ts
@@ -1,0 +1,125 @@
+import type { ProxyOptions } from 'vite'
+
+/**
+ * Proxy dev : une URL par cible, vide = route désactivée (hybride local / k8s / etc.).
+ * Variables lues depuis .env (loadEnv prefix '' dans vite.config).
+ */
+const E = {
+  back: 'VITE_DEV_PROXY_BACK',
+  fhir: 'VITE_DEV_PROXY_FHIR',
+  request: 'VITE_DEV_PROXY_REQUEST',
+  datamodel: 'VITE_DEV_PROXY_DATAMODEL',
+  portail: 'VITE_DEV_PROXY_PORTAIL',
+  secure: 'VITE_DEV_PROXY_SECURE'
+} as const
+
+/** TLS upstream : true par défaut ; `VITE_DEV_PROXY_SECURE=false` pour auto-signé / proxy d’entreprise. */
+function tlsVerify(envVal: string | undefined): boolean {
+  const x = (envVal ?? 'true').trim().toLowerCase()
+  return !['0', 'false', 'no'].includes(x)
+}
+
+/**
+ * FhirApi local attend souvent `authorizationMethod: OIDC` (RS256) alors que `oidcAuth` reste false
+ * pour le back Django (JWT). Sans toucher au code React : même rôle qu’un nginx qui ajoute le header
+ * sur /fhir. Voir `VITE_DEV_PROXY_FHIR_AUTH_METHOD` dans `.env.dev-proxy.example`.
+ */
+function withFhirAuthHeaderOverride(
+  opts: ProxyOptions,
+  mode: 'OIDC' | undefined
+): ProxyOptions {
+  if (mode !== 'OIDC') {
+    return opts
+  }
+  const prevConfigure = opts.configure
+  return {
+    ...opts,
+    configure(proxy, options) {
+      prevConfigure?.(proxy, options)
+      proxy.on('proxyReq', (proxyReq) => {
+        proxyReq.setHeader('authorizationMethod', 'OIDC')
+      })
+    }
+  }
+}
+
+export function buildDevProxy(env: Record<string, string | undefined>): Record<string, ProxyOptions> {
+  const secure = tlsVerify(env[E.secure])
+  const proxy: Record<string, ProxyOptions> = {}
+
+  const back = env[E.back]?.trim()
+  const fhir = env[E.fhir]?.trim()
+  const requestRaw = env[E.request]?.trim()
+  const request =
+    requestRaw === '-' || requestRaw === 'off'
+      ? undefined
+      : requestRaw || fhir
+  const datamodel = env[E.datamodel]?.trim()
+  const fhirAuthOverride =
+    env.VITE_DEV_PROXY_FHIR_AUTH_METHOD?.trim().toUpperCase() === 'OIDC' ? ('OIDC' as const) : undefined
+
+  const baseOpts = (): ProxyOptions => ({
+    changeOrigin: true,
+    secure
+  })
+
+  if (back) {
+    proxy['/api/back/ws'] = {
+      ...baseOpts(),
+      target: back,
+      ws: true,
+      rewrite: (path) => path.replace(/^\/api\/back\/ws/, '/ws')
+    }
+    proxy['/api/back'] = {
+      ...baseOpts(),
+      target: back,
+      rewrite: (path) => path.replace(/^\/api\/back/, '') || '/'
+    }
+    // Filet de sécurité : /auth/... sans préfixe /api/back (regex pour ne pas matcher /author…).
+    proxy['^/auth/'] = {
+      ...baseOpts(),
+      target: back
+    }
+  }
+
+  const portailTarget = env[E.portail]?.trim() || back
+  if (portailTarget) {
+    proxy['/api/portail'] = {
+      ...baseOpts(),
+      target: portailTarget,
+      rewrite: (path) => path.replace(/^\/api\/portail/, '') || '/'
+    }
+  }
+
+  if (fhir) {
+    proxy['/api/fhir'] = withFhirAuthHeaderOverride(
+      {
+        ...baseOpts(),
+        target: fhir,
+        rewrite: (path) => path.replace(/^\/api\/fhir/, '/fhir')
+      },
+      fhirAuthOverride
+    )
+  }
+
+  if (request) {
+    proxy['/api/request'] = withFhirAuthHeaderOverride(
+      {
+        ...baseOpts(),
+        target: request,
+        rewrite: (path) => path.replace(/^\/api\/request/, '/fhir')
+      },
+      fhirAuthOverride
+    )
+  }
+
+  if (datamodel) {
+    proxy['/api/datamodel'] = {
+      ...baseOpts(),
+      target: datamodel,
+      rewrite: (path) => path.replace(/^\/api\/datamodel/, '') || '/'
+    }
+  }
+
+  return proxy
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, normalizePath } from 'vite'
+import { defineConfig, loadEnv, normalizePath } from 'vite'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import svgr from 'vite-plugin-svgr'
@@ -8,19 +8,37 @@ import path from 'node:path'
 import { createRequire } from 'node:module'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
+import { buildDevProxy } from './vite-dev-proxy'
+
 const require = createRequire(import.meta.url)
 const cMapsDir = normalizePath(path.join(path.dirname(require.resolve('pdfjs-dist/package.json')), 'cmaps'))
 const standardFontsDir = normalizePath(
   path.join(path.dirname(require.resolve('pdfjs-dist/package.json')), 'standard_fonts')
 )
 
-export default defineConfig(() => {
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const proxy = buildDevProxy(env)
+  const proxyKeys = Object.keys(proxy)
+
+  if (mode === 'development') {
+    if (proxyKeys.length > 0) {
+      const back = env.VITE_DEV_PROXY_BACK?.trim()
+      console.info(`[cohort360] dev proxy (${proxyKeys.length} règles)${back ? ` → back ${back}` : ''}`)
+    } else if ((env.VITE_BACK_API_URL ?? '').startsWith('/')) {
+      console.warn(
+        '[cohort360] Aucun VITE_DEV_PROXY_* : sans Nginx, les URLs relatives type VITE_BACK_API_URL ne seront pas routées. Voir .env.dev-proxy.example'
+      )
+    }
+  }
+
   return {
     build: {
       outDir: 'build'
     },
     server: {
-      port: 3000
+      port: 3000,
+      ...(proxyKeys.length > 0 ? { proxy } : {})
     },
     plugins: [
       react(),


### PR DESCRIPTION
## Description
- Added `.env.dev-proxy.example` for local development proxy settings.
- Added `vite-dev-proxy.ts` to handle proxy logic for various API endpoints.
- Updated `vite.config.ts` to integrate proxy configuration based on environment variables.
