### PR TITLE
fix(export): always send all questionnaire IDs in pivot merge to prevent DE crash #3116

### DIFF
--- a/src/pages/ExportRequest/components/ExportTable/index.tsx
+++ b/src/pages/ExportRequest/components/ExportTable/index.tsx
@@ -121,7 +121,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
   const limit = appConfig.features.export.exportLinesLimit
   const [isQuestionChoiceOpen, setIsQuestionChoiceOpen] = useState<boolean>(false)
   const [selectedQuestions, setSelectedQuestions] = useState<QuestionLeaf[]>([])
-  const [selectedQuestionnaireIds, setSelectedQuestionnaireIds] = useState<string[]>([])
+  const [pivotColumns, setPivotColumns] = useState<string[]>([])
   const [isExtended, setIsExtended] = useState<boolean>(false)
   const [defaultQuestionnaireIds, setDefaultQuestionnaireIds] = useState<string[]>([])
 
@@ -130,9 +130,9 @@ const ExportTable: React.FC<ExportTableProps> = ({
     return table
   }
 
-  const onSelectedQuestionsChange = (questions: QuestionLeaf[], questionnaireId: string[]) => {
+  const onSelectedQuestionsChange = (questions: QuestionLeaf[], columns: string[]) => {
     setSelectedQuestions(questions)
-    setSelectedQuestionnaireIds(questionnaireId)
+    setPivotColumns(columns)
   }
 
   const onDisableSelectedTable = () => {
@@ -150,8 +150,13 @@ const ExportTable: React.FC<ExportTableProps> = ({
     setIsQuestionChoiceOpen(!isOpen)
   }
 
-  const handleDeleteSelectedQuestions = (newSelectedQuestions: QuestionLeaf[]) => {
+  const handleDeleteSelectedQuestions = (newSelectedQuestions: QuestionLeaf[], removedLinkId: string) => {
     setSelectedQuestions(newSelectedQuestions)
+    if (newSelectedQuestions.length === 0) {
+      setPivotColumns([])
+    } else {
+      setPivotColumns((prev) => prev.filter((col) => col !== removedLinkId))
+    }
   }
 
   const getFilterList = useCallback(async () => {
@@ -215,28 +220,22 @@ const ExportTable: React.FC<ExportTableProps> = ({
   }, [exportTableResourceType, getFilterCount, getQuestionnaireResponseCountDetails, cohortId])
 
   useEffect(() => {
-    if (checkedPivotMerge) {
-      onChangeTableSettings([{ tableName: exportTable.name, key: 'pivotMergeColumns', value: [] }])
-    }
-    if (checkedPivotMerge && defaultQuestionnaireIds.length > 0) {
-      onChangeTableSettings([{ tableName: exportTable.name, key: 'pivotMergeIds', value: defaultQuestionnaireIds }])
-    }
     if (!checkedPivotMerge) {
       onChangeTableSettings([
         { tableName: exportTable.name, key: 'pivotMergeColumns', value: undefined },
         { tableName: exportTable.name, key: 'pivotMergeIds', value: undefined }
       ])
+      return
     }
-    if (checkedPivotMerge && selectedQuestions.length > 0) {
-      onChangeTableSettings([
-        { tableName: exportTable.name, key: 'pivotMergeColumns', value: selectedQuestions.map((q) => q.linkId) },
-        { tableName: exportTable.name, key: 'pivotMergeIds', value: selectedQuestionnaireIds }
-      ])
-    }
+
+    onChangeTableSettings([
+      { tableName: exportTable.name, key: 'pivotMergeColumns', value: pivotColumns },
+      { tableName: exportTable.name, key: 'pivotMergeIds', value: defaultQuestionnaireIds }
+    ])
   }, [
     exportTable.fhirResourceName === ResourceType.QUESTIONNAIRE_RESPONSE,
     checkedPivotMerge,
-    selectedQuestions,
+    pivotColumns,
     defaultQuestionnaireIds
   ])
 
@@ -256,6 +255,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
           onConfirm: () => {
             removeTableSetting(exportTable.name)
             setSelectedQuestions([])
+            setPivotColumns([])
             setCheckedPivotMerge(false)
             dispatch(hideDialog())
           }
@@ -332,6 +332,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
               } else {
                 removeTableSetting(exportTable.name)
                 setSelectedQuestions([])
+                setPivotColumns([])
                 setCheckedPivotMerge(false)
               }
             }}
@@ -499,8 +500,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
                     label={l.text ?? l.linkId}
                     onDelete={() => {
                       const newSelectedQuestions = selectedQuestions.filter((q) => q.linkId !== l.linkId)
-                      handleDeleteSelectedQuestions(newSelectedQuestions)
-                      setSelectedQuestions(newSelectedQuestions)
+                      handleDeleteSelectedQuestions(newSelectedQuestions, l.linkId)
                     }}
                     style={{ backgroundColor: '#f7f7f7', margin: '0 5px 5px 0' }}
                   />

--- a/src/pages/ExportRequest/components/QuestionChoice/index.tsx
+++ b/src/pages/ExportRequest/components/QuestionChoice/index.tsx
@@ -88,7 +88,7 @@ interface QuestionSelectorDialogProps {
   onClose: () => void
   selectedQuestions: QuestionLeaf[]
   onDefaultQuestionnaireIds: (questionnaireIds: string[]) => void
-  onConfirm: (selected: QuestionLeaf[], selectedQuestionnaireIds: string[]) => void
+  onConfirm: (selected: QuestionLeaf[], pivotColumns: string[]) => void
 }
 
 /***********************************
@@ -380,19 +380,22 @@ const QuestionSelectorDialog: React.FC<QuestionSelectorDialogProps> = ({
     })
   }
 
-  const getQuestionnaireIdBySelectedLeaves = () => {
-    const questionnaireIds = new Set<string>()
-    checkedByQuestionnaire.forEach((set, qId) => {
-      if (set.size > 0) {
-        questionnaireIds.add(qId)
+  const buildPivotColumns = (): string[] => {
+    const hasAnySelection = Array.from(checkedByQuestionnaire.values()).some((set) => set.size > 0)
+    if (!hasAnySelection) return []
+
+    return questionnaires.flatMap((q) => {
+      const checked = checkedByQuestionnaire.get(q.id)
+      if (checked && checked.size > 0) {
+        return Array.from(checked)
       }
+      return collectLeaves(q.item).map((l) => l.linkId)
     })
-    return Array.from(questionnaireIds)
   }
 
   const handleConfirm = () => {
-    const pivotQuestionnaireIds = getQuestionnaireIdBySelectedLeaves()
-    onConfirm(allSelectedLeaves, pivotQuestionnaireIds)
+    const pivotColumns = buildPivotColumns()
+    onConfirm(allSelectedLeaves, pivotColumns)
     setInputQuery('') // reset search input
     setCheckedByQuestionnaire(new Map()) // reset checked state
     onClose()


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes ID/design-et-produit/ipa/cohort360/gestion-de-projet#3116

## Description
<!-- Concisely describe what the pull request does. -->
When selecting questions from a single form (FG or FH), the frontend was
sending only that form's ID in pivot_merge_ids. The Data Exporter crashes
on single-ID idsToMerge. Fix by always sending all default questionnaire
IDs and building the full pivot column list (selected + all columns from
unselected forms) so the DE receives 2 IDs in every case.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Following cases described in ticket #3116
