### PR TITLE
fix(auth): fix login flow, token validation and cross-tab sync - ref gestion-de-projet#2827

### DIFF
--- a/src/components/Routes/AppNavigation/AppNavigation.tsx
+++ b/src/components/Routes/AppNavigation/AppNavigation.tsx
@@ -1,5 +1,5 @@
-import React, { PropsWithChildren } from 'react'
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import React, { PropsWithChildren, useEffect } from 'react'
+import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-router-dom'
 
 import { useAppSelector } from 'state/index'
 
@@ -10,9 +10,26 @@ import AutoLogoutContainer from '../AutoLogoutContainer'
 import { WebSocketProvider } from 'components/WebSocket/WebSocketProvider'
 import Maintenance from 'views/Maintenance'
 import Snackbar from 'components/Snackbar/Snackbar'
+import { ACCESS_TOKEN } from 'constants.js'
 
 type LayoutProps = {
   displaySideBar: boolean
+}
+
+const CrossTabAuthSync = () => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const onStorageChange = (e: StorageEvent) => {
+      if (e.key === ACCESS_TOKEN && !e.newValue && window.location.pathname !== '/') {
+        navigate('/', { replace: true })
+      }
+    }
+    window.addEventListener('storage', onStorageChange)
+    return () => window.removeEventListener('storage', onStorageChange)
+  }, [navigate])
+
+  return null
 }
 
 const Layout = (props: PropsWithChildren<LayoutProps>) => {
@@ -35,6 +52,7 @@ const AppNavigation = () => {
   }
   return (
     <Router>
+      <CrossTabAuthSync />
       <Routes>
         {configRoutes().map((route, index) => {
           return route.isPrivate ? (

--- a/src/components/Routes/AutoLogoutContainer.tsx
+++ b/src/components/Routes/AutoLogoutContainer.tsx
@@ -138,12 +138,11 @@ const AutoLogoutContainer = () => {
    * 4. Dispatches logout action to Redux store
    * 5. Pauses the idle timer
    */
-  const logout = () => {
+  const logout = async () => {
     dispatch(closeAction())
-    navigate('/')
-    localStorage.clear()
-    dispatch(logoutAction())
     pause()
+    await dispatch(logoutAction())
+    navigate('/')
   }
 
   /**
@@ -179,17 +178,30 @@ const AutoLogoutContainer = () => {
    */
   const refreshToken = async () => {
     try {
-      const res = await apiBackend.post(`/auth/refresh/`, { refresh_token: localStorage.getItem(REFRESH_TOKEN) })
+      const currentRefreshToken = localStorage.getItem(REFRESH_TOKEN)
+      if (!currentRefreshToken) {
+        await logout()
+        return
+      }
+
+      const res = await apiBackend.post(`/auth/refresh/`, { refresh_token: currentRefreshToken })
 
       if (res.status === 200) {
+        if (!res.data.access_token) {
+          await logout()
+          return
+        }
+
         localStorage.setItem(ACCESS_TOKEN, res.data.access_token)
-        localStorage.setItem(REFRESH_TOKEN, res.data.refresh_token)
+        if (res.data.refresh_token) {
+          localStorage.setItem(REFRESH_TOKEN, res.data.refresh_token)
+        }
       } else {
-        logout()
+        await logout()
       }
     } catch (error) {
       console.error(error)
-      logout()
+      await logout()
     }
   }
 

--- a/src/components/Routes/PrivateRoute.tsx
+++ b/src/components/Routes/PrivateRoute.tsx
@@ -23,7 +23,7 @@ import { Outlet, Navigate, useLocation } from 'react-router-dom'
 
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from '@mui/material'
 
-import { ACCESS_TOKEN } from '../../constants'
+import { isAccessTokenValid } from 'utils/tokens'
 
 import { useAppSelector, useAppDispatch } from '../../state'
 import { AppConfig } from 'config'
@@ -76,7 +76,7 @@ const PrivateRoute: React.FC = () => {
   const dispatch = useAppDispatch()
   const appConfig = useContext(AppConfig)
   const location = useLocation()
-  const authToken = localStorage.getItem(ACCESS_TOKEN)
+  const hasValidToken = isAccessTokenValid()
   const [fetchedFhirMetadata, setFetchedFhirMetadata] = useState(false)
 
   /** State to control when redirection to login page is allowed */
@@ -117,15 +117,15 @@ const PrivateRoute: React.FC = () => {
         console.error(error)
       }
     }, 1000)
-    if (me && authToken) {
+    if (me && hasValidToken) {
       if (!fetchedFhirMetadata) {
         callFetchFhirMetadata()
       }
     }
-  }, [me, authToken, fetchedFhirMetadata])
+  }, [me, hasValidToken, fetchedFhirMetadata])
 
   // Authentication check: user must be authenticated and have a valid token
-  if (!me || (!me && !authToken)) {
+  if (!me || !hasValidToken) {
     // If user has confirmed the dialog, redirect to login page
     if (allowRedirect === true) return <Navigate to="/" replace />
 

--- a/src/components/Routes/__tests__/PrivateRoute.test.tsx
+++ b/src/components/Routes/__tests__/PrivateRoute.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+vi.mock('state', () => ({
+  useAppSelector: vi.fn(),
+  useAppDispatch: vi.fn(() => vi.fn())
+}))
+
+vi.mock('services/aphp/serviceFhirConfig', () => ({
+  updateConfigFromFhirMetadata: vi.fn()
+}))
+
+vi.mock('lodash', () => ({
+  throttle: (callback: () => void) => callback
+}))
+
+import { AppConfig } from 'config'
+import { useAppSelector } from 'state'
+import PrivateRoute from '../PrivateRoute'
+import { ACCESS_TOKEN } from 'constants'
+
+const mockedUseAppSelector = vi.mocked(useAppSelector)
+
+const makeJwt = (exp: number) => {
+  const header = btoa(JSON.stringify({ alg: 'HS256' }))
+  const payload = btoa(JSON.stringify({ exp }))
+  return `${header}.${payload}.signature`
+}
+
+const renderPrivateRoute = () =>
+  render(
+    <AppConfig.Provider value={{ system: { userTrackingBlacklist: [] } }}>
+      <MemoryRouter initialEntries={['/private']}>
+        <Routes>
+          <Route element={<PrivateRoute />}>
+            <Route path="/private" element={<div>private content</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </AppConfig.Provider>
+  )
+
+const meState = { me: { id: 'user-1' } }
+
+describe('PrivateRoute', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockedUseAppSelector.mockImplementation((selector) => selector({ me: null } as never))
+  })
+
+  it("bloque l'accès quand me est null", () => {
+    renderPrivateRoute()
+    expect(screen.getByText(/vous allez être redirigé vers la page de connexion/i)).toBeInTheDocument()
+  })
+
+  it("bloque l'accès quand access_token est absent même avec me", () => {
+    mockedUseAppSelector.mockImplementation((selector) => selector(meState as never))
+    renderPrivateRoute()
+    expect(screen.getByText(/vous allez être redirigé vers la page de connexion/i)).toBeInTheDocument()
+  })
+
+  it("bloque l'accès quand le token est expiré", () => {
+    const expiredToken = makeJwt(Math.floor(Date.now() / 1000) - 3600)
+    localStorage.setItem(ACCESS_TOKEN, expiredToken)
+    mockedUseAppSelector.mockImplementation((selector) => selector(meState as never))
+    renderPrivateRoute()
+    expect(screen.getByText(/vous allez être redirigé vers la page de connexion/i)).toBeInTheDocument()
+  })
+
+  it('laisse passer quand me et token valide existent', () => {
+    const validToken = makeJwt(Math.floor(Date.now() / 1000) + 3600)
+    localStorage.setItem(ACCESS_TOKEN, validToken)
+    mockedUseAppSelector.mockImplementation((selector) => selector(meState as never))
+    renderPrivateRoute()
+    expect(screen.getByText('private content')).toBeInTheDocument()
+  })
+})

--- a/src/components/Routes/__tests__/PrivateRoute.test.tsx
+++ b/src/components/Routes/__tests__/PrivateRoute.test.tsx
@@ -15,10 +15,10 @@ vi.mock('lodash', () => ({
   throttle: (callback: () => void) => callback
 }))
 
-import { AppConfig } from 'config'
+import { AppConfig, type AppConfig as AppConfigType } from 'config'
 import { useAppSelector } from 'state'
 import PrivateRoute from '../PrivateRoute'
-import { ACCESS_TOKEN } from 'constants'
+import { ACCESS_TOKEN } from 'constants.js'
 
 const mockedUseAppSelector = vi.mocked(useAppSelector)
 
@@ -30,7 +30,7 @@ const makeJwt = (exp: number) => {
 
 const renderPrivateRoute = () =>
   render(
-    <AppConfig.Provider value={{ system: { userTrackingBlacklist: [] } }}>
+    <AppConfig.Provider value={{ system: { userTrackingBlacklist: [] } } as unknown as AppConfigType}>
       <MemoryRouter initialEntries={['/private']}>
         <Routes>
           <Route element={<PrivateRoute />}>

--- a/src/services/__tests__/apiClients.test.ts
+++ b/src/services/__tests__/apiClients.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import type { InternalAxiosRequestConfig } from 'axios'
-import { ACCESS_TOKEN } from 'constants'
+import type { AxiosInterceptorManager, InternalAxiosRequestConfig } from 'axios'
+import { ACCESS_TOKEN } from 'constants.js'
 
 vi.mock('config', () => ({
   getConfig: () => ({
@@ -15,13 +15,20 @@ vi.mock('config', () => ({
 import apiBackend from 'services/apiBackend'
 import apiFhir, { getAuthorizationMethod } from 'services/apiFhir'
 
+type InterceptorHandler = {
+  fulfilled?: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>
+}
+
+const getRequestHandler = (interceptors: AxiosInterceptorManager<InternalAxiosRequestConfig>) =>
+  (interceptors as unknown as { handlers: InterceptorHandler[] }).handlers[0].fulfilled
+
 describe('api clients interceptors', () => {
   beforeEach(() => {
     localStorage.clear()
   })
 
   it("n'envoie pas Bearer null sur apiBackend", async () => {
-    const requestHandler = apiBackend.interceptors.request.handlers[0].fulfilled
+    const requestHandler = getRequestHandler(apiBackend.interceptors.request)
     const requestConfig = { headers: {} } as InternalAxiosRequestConfig
 
     const updatedConfig = await requestHandler?.(requestConfig)
@@ -33,7 +40,7 @@ describe('api clients interceptors', () => {
   it('ajoute Authorization quand un access token existe (apiBackend)', async () => {
     localStorage.setItem(ACCESS_TOKEN, 'access-value')
     localStorage.setItem('oidcAuth', 'true')
-    const requestHandler = apiBackend.interceptors.request.handlers[0].fulfilled
+    const requestHandler = getRequestHandler(apiBackend.interceptors.request)
     const requestConfig = { headers: {} } as InternalAxiosRequestConfig
 
     const updatedConfig = await requestHandler?.(requestConfig)
@@ -43,7 +50,7 @@ describe('api clients interceptors', () => {
   })
 
   it("n'envoie pas Bearer null sur apiFhir", async () => {
-    const requestHandler = apiFhir.interceptors.request.handlers[0].fulfilled
+    const requestHandler = getRequestHandler(apiFhir.interceptors.request)
     const requestConfig = { headers: {} } as InternalAxiosRequestConfig
 
     const updatedConfig = await requestHandler?.(requestConfig)

--- a/src/services/__tests__/apiClients.test.ts
+++ b/src/services/__tests__/apiClients.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { InternalAxiosRequestConfig } from 'axios'
+import { ACCESS_TOKEN } from 'constants'
+
+vi.mock('config', () => ({
+  getConfig: () => ({
+    system: {
+      backendUrl: 'http://backend.local',
+      fhirUrl: 'http://fhir.local'
+    }
+  }),
+  onUpdateConfig: vi.fn()
+}))
+
+import apiBackend from 'services/apiBackend'
+import apiFhir, { getAuthorizationMethod } from 'services/apiFhir'
+
+describe('api clients interceptors', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("n'envoie pas Bearer null sur apiBackend", async () => {
+    const requestHandler = apiBackend.interceptors.request.handlers[0].fulfilled
+    const requestConfig = { headers: {} } as InternalAxiosRequestConfig
+
+    const updatedConfig = await requestHandler?.(requestConfig)
+
+    expect(updatedConfig?.headers.Authorization).toBeUndefined()
+    expect(updatedConfig?.headers.authorizationMethod).toBe('JWT')
+  })
+
+  it('ajoute Authorization quand un access token existe (apiBackend)', async () => {
+    localStorage.setItem(ACCESS_TOKEN, 'access-value')
+    localStorage.setItem('oidcAuth', 'true')
+    const requestHandler = apiBackend.interceptors.request.handlers[0].fulfilled
+    const requestConfig = { headers: {} } as InternalAxiosRequestConfig
+
+    const updatedConfig = await requestHandler?.(requestConfig)
+
+    expect(updatedConfig?.headers.Authorization).toBe('Bearer access-value')
+    expect(updatedConfig?.headers.authorizationMethod).toBe('OIDC')
+  })
+
+  it("n'envoie pas Bearer null sur apiFhir", async () => {
+    const requestHandler = apiFhir.interceptors.request.handlers[0].fulfilled
+    const requestConfig = { headers: {} } as InternalAxiosRequestConfig
+
+    const updatedConfig = await requestHandler?.(requestConfig)
+
+    expect(updatedConfig?.headers.Authorization).toBeUndefined()
+    expect(updatedConfig?.headers.authorizationMethod).toBe('JWT')
+  })
+
+  it('déduit correctement authorizationMethod pour OIDC/JWT', () => {
+    expect(getAuthorizationMethod()).toBe('JWT')
+    localStorage.setItem('oidcAuth', 'true')
+    expect(getAuthorizationMethod()).toBe('OIDC')
+  })
+})

--- a/src/services/aphp/servicePractitioner.ts
+++ b/src/services/aphp/servicePractitioner.ts
@@ -65,7 +65,12 @@ const servicePractitioner: IServicePractitioner = {
   },
 
   logout: async (): Promise<void> => {
-    await apiBackend.post(`/auth/logout/`, { refresh_token: localStorage.getItem(REFRESH_TOKEN) })
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN)
+
+    if (refreshToken) {
+      await apiBackend.post(`/auth/logout/`, { refresh_token: refreshToken })
+    }
+
     localStorage.clear()
   },
 

--- a/src/services/apiBackend.ts
+++ b/src/services/apiBackend.ts
@@ -24,7 +24,11 @@ apiBackend.interceptors.request.use((config) => {
   const oidcAuthState = localStorage.getItem('oidcAuth')
   const token = localStorage.getItem(ACCESS_TOKEN)
 
-  config.headers.Authorization = `Bearer ${token}`
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  } else {
+    delete config.headers.Authorization
+  }
   config.headers.authorizationMethod = oidcAuthState === 'true' ? 'OIDC' : 'JWT'
 
   requestsConfigHooks.forEach((hook) => hook(config))

--- a/src/services/apiFhir.ts
+++ b/src/services/apiFhir.ts
@@ -29,7 +29,11 @@ export const getAuthorizationMethod = () => {
 apiFhir.interceptors.request.use((config) => {
   const token = localStorage.getItem(ACCESS_TOKEN)
 
-  config.headers.Authorization = `Bearer ${token}`
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  } else {
+    delete config.headers.Authorization
+  }
   config.headers.authorizationMethod = getAuthorizationMethod()
 
   requestsConfigHooks.forEach((hook) => hook(config))

--- a/src/state/me.ts
+++ b/src/state/me.ts
@@ -55,8 +55,7 @@ export type MeState = null | {
  * @returns Promise resolving to null (cleared state)
  */
 const logout = createAsyncThunk<MeState, void, { state: RootState }>('scope/logout', async () => {
-  services.practitioner.logout()
-  // Clear impersonation data from localStorage on logout
+  await services.practitioner.logout()
   localStorage.removeItem(IMPERSONATED_USER)
   return null
 })

--- a/src/utils/__tests__/tokens.test.ts
+++ b/src/utils/__tests__/tokens.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { isTokenExpired, isAccessTokenValid } from 'utils/tokens'
+import { ACCESS_TOKEN } from 'constants'
+
+const makeJwt = (payload: Record<string, unknown>) => {
+  const header = btoa(JSON.stringify({ alg: 'HS256' }))
+  const body = btoa(JSON.stringify(payload))
+  return `${header}.${body}.signature`
+}
+
+describe('isTokenExpired', () => {
+  it('retourne true si token est null', () => {
+    expect(isTokenExpired(null)).toBe(true)
+  })
+
+  it('retourne true si token est malformé', () => {
+    expect(isTokenExpired('not-a-jwt')).toBe(true)
+  })
+
+  it('retourne true si exp est dans le passé', () => {
+    const token = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 })
+    expect(isTokenExpired(token)).toBe(true)
+  })
+
+  it('retourne false si exp est dans le futur', () => {
+    const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    expect(isTokenExpired(token)).toBe(false)
+  })
+
+  it('retourne false si pas de champ exp (token sans expiry)', () => {
+    const token = makeJwt({ sub: 'user' })
+    expect(isTokenExpired(token)).toBe(false)
+  })
+})
+
+describe('isAccessTokenValid', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('retourne false si pas de token en localStorage', () => {
+    expect(isAccessTokenValid()).toBe(false)
+  })
+
+  it('retourne true si token valide en localStorage', () => {
+    const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    localStorage.setItem(ACCESS_TOKEN, token)
+    expect(isAccessTokenValid()).toBe(true)
+  })
+})

--- a/src/utils/__tests__/tokens.test.ts
+++ b/src/utils/__tests__/tokens.test.ts
@@ -27,9 +27,9 @@ describe('isTokenExpired', () => {
     expect(isTokenExpired(token)).toBe(false)
   })
 
-  it('retourne false si pas de champ exp (token sans expiry)', () => {
+  it('retourne true si pas de champ exp (token sans expiry)', () => {
     const token = makeJwt({ sub: 'user' })
-    expect(isTokenExpired(token)).toBe(false)
+    expect(isTokenExpired(token)).toBe(true)
   })
 })
 

--- a/src/utils/__tests__/tokens.test.ts
+++ b/src/utils/__tests__/tokens.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { isTokenExpired, isAccessTokenValid } from 'utils/tokens'
-import { ACCESS_TOKEN } from 'constants'
+import { ACCESS_TOKEN } from 'constants.js'
 
 const makeJwt = (payload: Record<string, unknown>) => {
   const header = btoa(JSON.stringify({ alg: 'HS256' }))

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,0 +1,21 @@
+import { ACCESS_TOKEN } from 'constants.js'
+
+export const isTokenExpired = (token: string | null): boolean => {
+  if (!token) return true
+
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    if (!payload.exp) return false
+    return payload.exp * 1000 < Date.now()
+  } catch {
+    return true
+  }
+}
+
+export const getStoredAccessToken = (): string | null => {
+  return localStorage.getItem(ACCESS_TOKEN)
+}
+
+export const isAccessTokenValid = (): boolean => {
+  return !isTokenExpired(getStoredAccessToken())
+}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -5,7 +5,7 @@ export const isTokenExpired = (token: string | null): boolean => {
 
   try {
     const payload = JSON.parse(atob(token.split('.')[1]))
-    if (!payload.exp) return false
+    if (!payload.exp) return true
     return payload.exp * 1000 < Date.now()
   } catch {
     return true

--- a/src/views/Login/Login.tsx
+++ b/src/views/Login/Login.tsx
@@ -7,7 +7,6 @@ import React, {
   useState
 } from 'react'
 import { useNavigate } from 'react-router-dom'
-import localforage from 'localforage'
 import {
   Alert,
   Box,
@@ -31,9 +30,10 @@ import logo from 'assets/images/logo-login.png'
 import logoAPHP from 'assets/images/logo-aphp.png'
 import Keycloak from 'assets/icones/keycloak.svg?react'
 
-import { useAppDispatch } from 'state'
+import { useAppDispatch, useAppSelector } from 'state'
 import { MeState, login as loginAction } from 'state/me'
 import { ACCESS_TOKEN, REFRESH_TOKEN } from 'constants.js'
+import { isAccessTokenValid } from 'utils/tokens'
 
 import services from 'services/aphp'
 
@@ -126,6 +126,7 @@ const Login = () => {
   const { classes, cx } = useStyles()
   const appConfig = useContext(AppConfig)
   const dispatch = useAppDispatch()
+  const me = useAppSelector((state) => state.me)
   const [loading, setLoading] = useState(false)
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -138,9 +139,16 @@ const Login = () => {
   const oidcCode = urlParams.get('code')
 
   useEffect(() => {
-    localforage.setItem('persist:root', '')
     if (oidcCode) login()
   }, [])
+
+  useEffect(() => {
+    if (!oidcCode && me && isAccessTokenValid()) {
+      const oldPath = localStorage.getItem('old-path')
+      localStorage.removeItem('old-path')
+      navigate(oldPath ?? '/home', { replace: true })
+    }
+  }, [me, navigate, oidcCode])
 
   const loadBootstrapData = async (practitionerData: User, lastConnection: string) => {
     const maintenanceResponse = await services.practitioner.maintenance()


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes gestion-de-projet#2827

## Description
<!-- Concisely describe what the pull request does. -->
- Prevent Bearer null in request headers (apiBackend, apiFhir)
- Check JWT expiry in PrivateRoute guard instead of just token presence
- Redirect to /home from / when already authenticated
- Fix logout order: await API call before clearing localStorage
- Guard refresh calls when refresh_token is missing or response incomplete
- Add cross-tab auth sync via storage event listener
- Add unit tests for interceptors, PrivateRoute guard and token utils
