### PR TITLE
refactor(serviceValueSets): paramètre "filter=*" en trop passé à une requete FHIR

### DIFF
--- a/src/services/aphp/serviceValueSets.ts
+++ b/src/services/aphp/serviceValueSets.ts
@@ -274,11 +274,10 @@ export const searchInValueSets = async (
   }
 
   const searchValue = search || HIERARCHY_ROOT
+  const filter = searchValue === HIERARCHY_ROOT ? '' : `&filter=${encodeURIComponent(searchValue)}`
   try {
     const res = await apiFhir.get<FHIR_API_Response<ValueSet>>(
-      `/ValueSet/$expand?activeOnly=true&url=${codeSystems.join(',')}&filter=${encodeURIComponent(
-        searchValue
-      )}&excludeNested=false&_tag=text-search-rank&_tag=${LOW_TOLERANCE_TAG}${options}`,
+      `/ValueSet/$expand?activeOnly=true&url=${codeSystems.join(',')}${filter}&excludeNested=false&_tag=text-search-rank&_tag=${LOW_TOLERANCE_TAG}${options}`,
       { signal }
     )
     const response = formatValuesetExpansion(getApiResponseResourceOrThrow(res).expansion)


### PR DESCRIPTION
## Fixes
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3219

