### PR TITLE
fix(export): prevent-multiple-export - Ref gestion-de-projet#2994

### DIFF
--- a/src/__tests__/components/DocumentViewer/DocumentViewer.test.tsx
+++ b/src/__tests__/components/DocumentViewer/DocumentViewer.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { DocumentReference } from 'fhir/r4'
+
+// Mocks
+vi.mock('services/aphp', () => ({
+  default: {
+    cohorts: {
+      fetchDocumentContent: vi.fn()
+    }
+  }
+}))
+
+vi.mock('config', () => ({
+  getConfig: () => ({
+    system: {
+      fhirUrl: 'http://fhir.example.com'
+    }
+  })
+}))
+
+vi.mock('services/apiFhir', () => ({
+  getAuthorizationMethod: () => 'Bearer'
+}))
+
+vi.mock('react-pdf', () => ({
+  pdfjs: {
+    GlobalWorkerOptions: { workerSrc: '' },
+    version: '3.0.0'
+  },
+  Document: ({ children }: { children: React.ReactNode }) => <div data-testid="pdf-document">{children}</div>,
+  Page: () => <div data-testid="pdf-page" />
+}))
+
+vi.mock('assets/images/watermark_pseudo.svg?react', () => ({
+  default: () => <svg data-testid="watermark" />
+}))
+
+vi.mock('html-react-parser', () => ({
+  default: (html: string) => html
+}))
+
+import DocumentViewer from 'components/DocumentViewer/DocumentViewer'
+import services from 'services/aphp'
+
+const mockFetchDocumentContent = vi.mocked(services.cohorts.fetchDocumentContent)
+
+const buildDocumentReference = (contentTypes: string[]): DocumentReference => ({
+  resourceType: 'DocumentReference',
+  status: 'current',
+  content: contentTypes.map((contentType) => ({
+    attachment: {
+      contentType,
+      data:
+        contentType === 'text/plain'
+          ? Buffer.from('<p>Contenu texte du document</p>').toString('base64')
+          : undefined
+    }
+  }))
+})
+
+const defaultProps = {
+  open: true,
+  handleClose: vi.fn(),
+  documentId: 'doc-123',
+  deidentified: false
+}
+
+describe('DocumentViewer - hasPdfContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("devrait afficher l'onglet PDF quand le document contient un contenu PDF et que l'utilisateur n'est pas déidentifié", async () => {
+    mockFetchDocumentContent.mockResolvedValue(
+      buildDocumentReference(['application/pdf', 'text/plain'])
+    )
+
+    render(<DocumentViewer {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'PDF' })).toBeInTheDocument()
+    })
+  })
+
+  it("ne devrait pas afficher l'onglet PDF quand le document ne contient pas de contenu PDF", async () => {
+    mockFetchDocumentContent.mockResolvedValue(buildDocumentReference(['text/plain']))
+
+    render(<DocumentViewer {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tab', { name: 'PDF' })).not.toBeInTheDocument()
+    })
+  })
+
+  it("ne devrait pas afficher l'onglet PDF quand l'utilisateur est déidentifié, même si le document contient un PDF", async () => {
+    mockFetchDocumentContent.mockResolvedValue(
+      buildDocumentReference(['application/pdf', 'text/plain'])
+    )
+
+    render(<DocumentViewer {...defaultProps} deidentified={true} />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tab', { name: 'PDF' })).not.toBeInTheDocument()
+    })
+  })
+
+  it("devrait afficher l'onglet 'Texte brut pseudonymisé' dans tous les cas", async () => {
+    mockFetchDocumentContent.mockResolvedValue(buildDocumentReference(['text/plain']))
+
+    render(<DocumentViewer {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Texte brut pseudonymisé' })).toBeInTheDocument()
+    })
+  })
+
+  it("devrait basculer vers l'onglet 'raw' si l'onglet PDF est sélectionné mais que le document ne contient pas de PDF", async () => {
+    // D'abord, on simule un document avec PDF (pour que l'onglet PDF soit visible)
+    mockFetchDocumentContent.mockResolvedValue(
+      buildDocumentReference(['application/pdf', 'text/plain'])
+    )
+
+    const { rerender } = render(<DocumentViewer {...defaultProps} documentId="doc-with-pdf" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'PDF' })).toBeInTheDocument()
+    })
+
+    // Ensuite, on change le documentId vers un document sans PDF
+    mockFetchDocumentContent.mockResolvedValue(buildDocumentReference(['text/plain']))
+
+    rerender(<DocumentViewer {...defaultProps} documentId="doc-without-pdf" />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tab', { name: 'PDF' })).not.toBeInTheDocument()
+    })
+  })
+
+  it("ne devrait pas afficher le contenu PDF quand hasPdfContent est false", async () => {
+    mockFetchDocumentContent.mockResolvedValue(buildDocumentReference(['text/plain']))
+
+    render(<DocumentViewer {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('pdf-document')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/__tests__/reducers/searchCriteriasReducer.test.ts
+++ b/src/__tests__/reducers/searchCriteriasReducer.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import useSearchCriterias from 'reducers/searchCriteriasReducer'
+import { Direction, Order, SearchCriterias } from 'types/searchCriterias'
+
+type TestFilters = { status: string[] }
+
+const initState: SearchCriterias<TestFilters> = {
+  orderBy: { orderBy: Order.ID, orderDirection: Direction.DESC },
+  searchInput: '',
+  filters: { status: [] }
+}
+
+describe('useSearchCriterias - comportement du resetKey', () => {
+  it("ne devrait pas réinitialiser l'état au montage initial", () => {
+    const { result } = renderHook(() => useSearchCriterias(initState, 'key-initial'))
+
+    const [state] = result.current
+    expect(state).toEqual(initState)
+  })
+
+  it("devrait réinitialiser l'état quand resetKey change", () => {
+    let resetKey = 'key-1'
+    const { result, rerender } = renderHook(() => useSearchCriterias(initState, resetKey))
+
+    // Modifier l'état via une action
+    act(() => {
+      const [, actions] = result.current
+      actions.changeSearchInput('test')
+    })
+
+    expect(result.current[0].searchInput).toBe('test')
+
+    // Changer le resetKey → doit déclencher REMOVE_SEARCH_CRITERIAS
+    resetKey = 'key-2'
+    rerender()
+
+    expect(result.current[0].searchInput).toBe('')
+    expect(result.current[0]).toEqual(initState)
+  })
+
+  it("ne devrait pas réinitialiser l'état si resetKey ne change pas", () => {
+    const { result, rerender } = renderHook(() => useSearchCriterias(initState, 'key-stable'))
+
+    act(() => {
+      const [, actions] = result.current
+      actions.changeSearchInput('valeur persistée')
+    })
+
+    expect(result.current[0].searchInput).toBe('valeur persistée')
+
+    // Re-render sans changer resetKey
+    rerender()
+
+    // L'état ne doit pas avoir été réinitialisé
+    expect(result.current[0].searchInput).toBe('valeur persistée')
+  })
+
+  it("devrait réinitialiser l'état à chaque changement successif de resetKey", () => {
+    let resetKey = 'key-a'
+    const { result, rerender } = renderHook(() => useSearchCriterias(initState, resetKey))
+
+    act(() => {
+      result.current[1].changeSearchInput('premier')
+    })
+    expect(result.current[0].searchInput).toBe('premier')
+
+    resetKey = 'key-b'
+    rerender()
+    expect(result.current[0].searchInput).toBe('')
+
+    act(() => {
+      result.current[1].changeSearchInput('deuxième')
+    })
+    expect(result.current[0].searchInput).toBe('deuxième')
+
+    resetKey = 'key-c'
+    rerender()
+    expect(result.current[0].searchInput).toBe('')
+    expect(result.current[0]).toEqual(initState)
+  })
+})

--- a/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/src/components/DocumentViewer/DocumentViewer.tsx
@@ -112,6 +112,16 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ deidentified, open, han
       ? Buffer.from(findContent.attachment.data, 'base64').toString('utf-8')
       : ''
 
+  const hasPdfContent = documentContent?.content?.some(
+    (content) => content.attachment?.contentType === 'application/pdf'
+  )
+
+  useEffect(() => {
+    if (selectedTab === 'pdf' && !hasPdfContent) {
+      setSelectedTab('raw')
+    }
+  }, [hasPdfContent, selectedTab])
+
   return (
     <Dialog open={open} fullWidth maxWidth="xl" onClose={handleClose}>
       <DialogContent id="document-viewer-dialog-content">
@@ -122,7 +132,7 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ deidentified, open, han
         ) : (
           <>
             <TabsWrapper value={selectedTab} onChange={handleTabChange} customVariant={'secondary'}>
-              {!deidentified && <Tab label="PDF" value="pdf" />}
+              {!deidentified && hasPdfContent && <Tab label="PDF" value="pdf" />}
               <Tab label="Texte brut pseudonymisé" value="raw" />
             </TabsWrapper>
             <>
@@ -137,7 +147,7 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ deidentified, open, han
               )}
             </>
             <>
-              {selectedTab === 'pdf' && (
+              {hasPdfContent && selectedTab === 'pdf' && (
                 <Grid id="salut" ref={gridRef} style={pdfViewerContainerStyle}>
                   <div id="document">
                     <Document

--- a/src/components/ExplorationBoard/config/documents.ts
+++ b/src/components/ExplorationBoard/config/documents.ts
@@ -188,7 +188,7 @@ export const mapToTable = (
       },
       {
         id: `${elem.id}-viewDoc`,
-        value: { id: elem.id, deidentified },
+        value: { id: elem.content ? elem.id : false, deidentified },
         type: CellType.DOCUMENT_VIEWER,
         align: 'center'
       },

--- a/src/components/ExplorationBoard/config/documents.ts
+++ b/src/components/ExplorationBoard/config/documents.ts
@@ -188,7 +188,7 @@ export const mapToTable = (
       },
       {
         id: `${elem.id}-viewDoc`,
-        value: { id: elem.content ? elem.id : false, deidentified },
+        value: { id: elem.content && elem.id, deidentified },
         type: CellType.DOCUMENT_VIEWER,
         align: 'center'
       },

--- a/src/reducers/searchCriteriasReducer.ts
+++ b/src/reducers/searchCriteriasReducer.ts
@@ -4,7 +4,7 @@
  */
 
 import { removeFilter } from 'utils/filters'
-import { useReducer, useEffect } from 'react'
+import { useReducer, useEffect, useRef } from 'react'
 import {
   ActionTypes,
   SearchCriterias,
@@ -130,7 +130,15 @@ const useSearchCriterias = <F>(
     () => initState
   )
 
+  // Evite un double fetch au montage initial : sans ce guard, le useEffect dispatche
+  // REMOVE_SEARCH_CRITERIAS dès le premier render, ce qui appelle initState() et crée
+  // un nouvel objet (nouvelle référence), forçant un re-render et retriggant les effets dépendants.
+  const isFirstRun = useRef(true)
   useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false
+      return
+    }
     dispatch({ type: ActionTypes.REMOVE_SEARCH_CRITERIAS, payload: null })
   }, [resetKey])
 

--- a/src/reducers/searchCriteriasReducer.ts
+++ b/src/reducers/searchCriteriasReducer.ts
@@ -130,7 +130,7 @@ const useSearchCriterias = <F>(
     () => initState
   )
 
-  // Ne dispatch que quand resetKey change réellement : évite qu'un REMOVE au mount                                                                                                                                 
+  // Ne dispatch que quand resetKey change réellement : évite qu'un REMOVE au mount
   // ne renvoie une nouvelle ref de initState et cascade en double fetch via useData.
   const prevResetKey = useRef(resetKey)
   useEffect(() => {

--- a/src/reducers/searchCriteriasReducer.ts
+++ b/src/reducers/searchCriteriasReducer.ts
@@ -130,15 +130,12 @@ const useSearchCriterias = <F>(
     () => initState
   )
 
-  // Evite un double fetch au montage initial : sans ce guard, le useEffect dispatche
-  // REMOVE_SEARCH_CRITERIAS dès le premier render, ce qui appelle initState() et crée
-  // un nouvel objet (nouvelle référence), forçant un re-render et retriggant les effets dépendants.
-  const isFirstRun = useRef(true)
+  // Ne dispatch que quand resetKey change réellement : évite qu'un REMOVE au mount                                                                                                                                 
+  // ne renvoie une nouvelle ref de initState et cascade en double fetch via useData.
+  const prevResetKey = useRef(resetKey)
   useEffect(() => {
-    if (isFirstRun.current) {
-      isFirstRun.current = false
-      return
-    }
+    if (prevResetKey.current === resetKey) return
+    prevResetKey.current = resetKey
     dispatch({ type: ActionTypes.REMOVE_SEARCH_CRITERIAS, payload: null })
   }, [resetKey])
 

--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -299,8 +299,7 @@ export const fetchDocumentReference = async (
 
   // By default, all the calls to `/DocumentReference` will have`'type:not=https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor'`, contenttype=text/plain, and patient.active=true in parameter
   let options: string[] = [
-    `type:not=${encodeURIComponent('https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor')}`,
-    `contenttype=${encodeURIComponent('text/plain')}`
+    `type:not=${encodeURIComponent('https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor')}`
   ]
 
   if (appConfig.core.fhir.totalCount) options = [...options, '_total=accurate']

--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -297,7 +297,7 @@ export const fetchDocumentReference = async (
   uniqueFacet = uniqueFacet ? uniqueFacet.filter(uniq) : []
   _elements = _elements ? _elements.filter(uniq) : []
 
-  // By default, all the calls to `/DocumentReference` will have`'type:not=https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor'`, contenttype=text/plain, and patient.active=true in parameter
+  // By default, all the calls to `/DocumentReference` will have `'type:not=https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor'` and patient.active=true in parameter
   let options: string[] = [
     `type:not=${encodeURIComponent('https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor')}`
   ]


### PR DESCRIPTION
## Fixes

Fixes [#2994](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/2994)

## Description
In explorationBoard:
- prevent a double call to FHIR in files Tab's
- display documents even if they do not contain PDFs and text


