### PR TITLE
fix(fhir): use POST _search to avoid HTTP 414 on long code lists

### DIFF
--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -1,4 +1,4 @@
-import apiFhir from '../apiFhir'
+import apiFhir, { fhirSearch } from '../apiFhir'
 import apiDatamodel from 'services/apiDatamodel'
 import {
   AccessExpiration,
@@ -149,7 +149,7 @@ export const fetchPatient = async (args: fetchPatientProps): FHIR_Bundle_Promise
     options = [...options, `pivot-facet=${pivotFacet.reduce(paramValuesReducer, '')}`]
   if (_elements && _elements.length > 0) options = [...options, `_elements=${_elements.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<Patient>>(`/Patient?${options.reduce(paramsReducer, '')}`, {
+  const response = await fhirSearch<FHIR_Bundle_Response<Patient>>('Patient', options, {
     signal: signal
   })
 
@@ -202,18 +202,15 @@ export const fetchEncounter = async (args: fetchEncounterProps): FHIR_Bundle_Pro
     options = [...options, `facet=${facet.reduce(paramValuesReducer, '')}`]
   if (visit !== undefined) options = [...options, `part-of:missing=${visit}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<Encounter>>(
-    `/Encounter?${options.reduce(paramsReducer, '')}`,
-    {
-      signal: signal
-    }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<Encounter>>('Encounter', options, {
+    signal: signal
+  })
 
   return response
 }
 
 export const fetchOrganization = async (encounterIds: string) => {
-  return await apiFhir.get<FHIR_Bundle_Response<Organization>>(`/Organization?_id=${encounterIds}`)
+  return await fhirSearch<FHIR_Bundle_Response<Organization>>('Organization', [`_id=${encounterIds}`])
 }
 
 /**
@@ -351,10 +348,9 @@ export const fetchDocumentReference = async (
     options = [...options, `unique-facet=${uniqueFacet.reduce(paramValuesReducer, '')}`]
   if (_elements && _elements.length > 0) options = [...options, `_elements=${_elements.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<DocumentReference>>(
-    `/DocumentReference?${options.reduce(paramsReducer, '')}`,
-    { signal: signal }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<DocumentReference>>('DocumentReference', options, {
+    signal: signal
+  })
 
   return response
 }
@@ -454,7 +450,7 @@ export const fetchBinary = async (args: fetchBinaryProps): FHIR_Bundle_Promise_R
 
   if (_id) options = [...options, `_id=${_id}`]
 
-  const documentResp = await apiFhir.get<FHIR_Bundle_Response<Binary>>(`/Binary?${options.reduce(paramsReducer, '')}`)
+  const documentResp = await fhirSearch<FHIR_Bundle_Response<Binary>>('Binary', options)
 
   return documentResp
 }
@@ -534,12 +530,9 @@ export const fetchProcedure = async (args: fetchProcedureProps): FHIR_Bundle_Pro
   if (appConfig.core.fhir.facetsExtensions && uniqueFacet && uniqueFacet.length > 0)
     options = [...options, `unique-facet=${uniqueFacet.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<Procedure>>(
-    `/Procedure?${options.reduce(paramsReducer, '')}`,
-    {
-      signal: args.signal
-    }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<Procedure>>('Procedure', options, {
+    signal: args.signal
+  })
 
   return response
 }
@@ -611,7 +604,7 @@ export const fetchClaim = async (args: fetchClaimProps): FHIR_Bundle_Promise_Res
 
   if (!patient && _list && _list.length > 0) options = [...options, `_list=${_list.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<Claim>>(`/Claim?${options.reduce(paramsReducer, '')}`, {
+  const response = await fhirSearch<FHIR_Bundle_Response<Claim>>('Claim', options, {
     signal: args.signal
   })
 
@@ -684,12 +677,9 @@ export const fetchCondition = async (args: fetchConditionProps): FHIR_Bundle_Pro
     options = [...options, `${ConditionParamsKeys.DIAGNOSTIC_TYPES}=${encodeURIComponent(urlString)}`]
   }
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<Condition>>(
-    `/Condition?${options.reduce(paramsReducer, '')}`,
-    {
-      signal: args.signal
-    }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<Condition>>('Condition', options, {
+    signal: args.signal
+  })
 
   return response
 }
@@ -768,12 +758,9 @@ export const fetchObservation = async (args: fetchObservationProps): FHIR_Bundle
 
   if (!subject && _list && _list.length > 0) options = [...options, `_list=${_list.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<Observation>>(
-    `/Observation?${options.reduce(paramsReducer, '')}`,
-    {
-      signal: signal
-    }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<Observation>>('Observation', options, {
+    signal: signal
+  })
 
   return response
 }
@@ -855,12 +842,9 @@ export const fetchMedicationRequest = async (
 
   if (!subject && _list && _list.length > 0) options = [...options, `_list=${_list.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<MedicationRequest>>(
-    `/MedicationRequest?${options.reduce(paramsReducer, '')}`,
-    {
-      signal: signal
-    }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<MedicationRequest>>('MedicationRequest', options, {
+    signal: signal
+  })
 
   return response
 }
@@ -941,8 +925,9 @@ export const fetchMedicationAdministration = async (
 
   if (!subject && _list && _list.length > 0) options = [...options, `_list=${_list.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<MedicationAdministration>>(
-    `/MedicationAdministration?${options.reduce(paramsReducer, '')}`,
+  const response = await fhirSearch<FHIR_Bundle_Response<MedicationAdministration>>(
+    'MedicationAdministration',
+    options,
     {
       signal: signal
     }
@@ -1021,12 +1006,9 @@ export const fetchImaging = async (args: fetchImagingProps): FHIR_Bundle_Promise
   if (appConfig.core.fhir.facetsExtensions && uniqueFacet && uniqueFacet.length > 0)
     options = [...options, `unique-facet=${uniqueFacet.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<ImagingStudy>>(
-    `/ImagingStudy?${options.reduce(paramsReducer, '')}`,
-    {
-      signal: signal
-    }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<ImagingStudy>>('ImagingStudy', options, {
+    signal: signal
+  })
 
   return response
 }
@@ -1089,10 +1071,9 @@ export const fetchForms = async (args: fetchFormsProps) => {
   if (appConfig.core.fhir.facetsExtensions && uniqueFacet && uniqueFacet.length > 0)
     options = [...options, `unique-facet=${uniqueFacet.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<QuestionnaireResponse>>(
-    `/QuestionnaireResponse?${options.reduce(paramsReducer, '')}`,
-    { signal: signal }
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<QuestionnaireResponse>>('QuestionnaireResponse', options, {
+    signal: signal
+  })
 
   return response
 }
@@ -1110,9 +1091,7 @@ export const fetchQuestionnaires = async (args: fetchQuestionnairesProps) => {
   if (name) options = [...options, `name=${name}`]
   if (_elements && _elements.length > 0) options = [...options, `_elements=${_elements.reduce(paramValuesReducer, '')}`]
 
-  const response = await apiFhir.get<FHIR_Bundle_Response<Questionnaire>>(
-    `/Questionnaire?${options.reduce(paramsReducer, '')}`
-  )
+  const response = await fhirSearch<FHIR_Bundle_Response<Questionnaire>>('Questionnaire', options)
 
   return response
 }
@@ -1138,8 +1117,7 @@ export const fetchLocation = async (args: fetchLocationProps) => {
 
   if (_list && _list.length > 0) options = [...options, `_list=${_list.filter(uniq).reduce(paramValuesReducer, '')}`]
 
-  const queryString = options.length > 0 ? `?${options.reduce(paramsReducer, '')}` : ''
-  const response = await apiFhir.get<FHIR_Bundle_Response<Location>>(`/Location${queryString}`, {
+  const response = await fhirSearch<FHIR_Bundle_Response<Location>>('Location', options, {
     signal
   })
 
@@ -1176,8 +1154,7 @@ export const fetchDiagnosticReport = async (args: fetchDiagnosticReportProps) =>
 
   if (_list && _list.length > 0) options = [...options, `_list=${_list.filter(uniq).reduce(paramValuesReducer, '')}`]
 
-  const queryString = options.length > 0 ? `?${options.reduce(paramsReducer, '')}` : ''
-  const response = await apiFhir.get<FHIR_Bundle_Response<DiagnosticReport>>(`/DiagnosticReport${queryString}`, {
+  const response = await fhirSearch<FHIR_Bundle_Response<DiagnosticReport>>('DiagnosticReport', options, {
     signal
   })
 

--- a/src/services/apiFhir.test.ts
+++ b/src/services/apiFhir.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import apiFhir, { fhirSearch } from './apiFhir'
+
+describe('fhirSearch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs to /{resource}/_search with form-urlencoded body', async () => {
+    const post = vi.spyOn(apiFhir, 'post').mockResolvedValue({ data: {} } as never)
+
+    await fhirSearch('Observation', ['code=loinc|1234,loinc|5678', '_count=20'])
+
+    expect(post).toHaveBeenCalledTimes(1)
+    const [url, body, config] = post.mock.calls[0]
+    expect(url).toBe('/Observation/_search')
+    expect(body).toBe('code=loinc|1234,loinc|5678&_count=20')
+    expect(config?.headers?.['Content-Type']).toBe('application/x-www-form-urlencoded')
+  })
+
+  it('drops empty params so trailing/empty options do not produce stray ampersands', async () => {
+    const post = vi.spyOn(apiFhir, 'post').mockResolvedValue({ data: {} } as never)
+
+    await fhirSearch('Patient', ['', '_count=10', '', 'gender=male', ''])
+
+    expect(post.mock.calls[0][1]).toBe('_count=10&gender=male')
+  })
+
+  it('handles an empty params list (search all)', async () => {
+    const post = vi.spyOn(apiFhir, 'post').mockResolvedValue({ data: {} } as never)
+
+    await fhirSearch('Encounter', [])
+
+    expect(post.mock.calls[0][0]).toBe('/Encounter/_search')
+    expect(post.mock.calls[0][1]).toBe('')
+  })
+
+  it('forwards AbortSignal and merges extra headers without losing the form content-type', async () => {
+    const post = vi.spyOn(apiFhir, 'post').mockResolvedValue({ data: {} } as never)
+    const controller = new AbortController()
+
+    await fhirSearch('Condition', ['_count=1'], {
+      signal: controller.signal,
+      headers: { 'X-Trace-Id': 'abc' }
+    })
+
+    const config = post.mock.calls[0][2]
+    expect(config?.signal).toBe(controller.signal)
+    expect(config?.headers?.['X-Trace-Id']).toBe('abc')
+    expect(config?.headers?.['Content-Type']).toBe('application/x-www-form-urlencoded')
+  })
+
+  it('preserves caller-provided value encoding verbatim in the body', async () => {
+    const post = vi.spyOn(apiFhir, 'post').mockResolvedValue({ data: {} } as never)
+    const encodedText = encodeURIComponent('hémoglobine glyquée')
+
+    await fhirSearch('Observation', [`_text=${encodedText}`, 'subject.active=true'])
+
+    expect(post.mock.calls[0][1]).toBe(`_text=${encodedText}&subject.active=true`)
+  })
+
+  it('keeps a long body intact instead of pushing it into the URL', async () => {
+    const post = vi.spyOn(apiFhir, 'post').mockResolvedValue({ data: {} } as never)
+    const codes = Array.from({ length: 500 }, (_, i) => `loinc|${i}`).join(',')
+
+    await fhirSearch('Observation', [`code=${codes}`])
+
+    const [url, body] = post.mock.calls[0]
+    expect(url).toBe('/Observation/_search')
+    expect((body as string).length).toBeGreaterThan(2000)
+    expect(url).not.toContain('code=')
+  })
+})

--- a/src/services/apiFhir.ts
+++ b/src/services/apiFhir.ts
@@ -1,4 +1,4 @@
-import axios, { InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { ACCESS_TOKEN } from '../constants'
 import { getConfig, onUpdateConfig } from 'config'
 
@@ -35,5 +35,20 @@ apiFhir.interceptors.request.use((config) => {
   requestsConfigHooks.forEach((hook) => hook(config))
   return config
 })
+
+export const fhirSearch = <T>(
+  resource: string,
+  params: string[],
+  config: AxiosRequestConfig = {}
+): Promise<AxiosResponse<T>> => {
+  const body = params.filter(Boolean).join('&')
+  return apiFhir.post<T>(`/${resource}/_search`, body, {
+    ...config,
+    headers: {
+      ...(config.headers ?? {}),
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
+  })
+}
 
 export default apiFhir


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3215

## Description
<!-- Concisely describe what the pull request does. -->
Selecting many biology codes in the cohort perimeter exploration generates URLs long enough to trigger `HTTP 414` from the FHIR Api (or frontend NGINX reverse proxy, source unsure).

Switch all FHIR resource searches to `POST [type]/_search` with an `application/x-www-form-urlencoded` body, as mandated by [FHIR R4](https://www.hl7.org/fhir/R4/search.html): same semantics as the `GET` form, avoiding URL length limit.

A new `fhirSearch` helper in services/apiFhir centralizes the POST, content-type and body serialization so every fetch* call site keeps the existing options[] param-building logic unchanged.