### PR TITLE
fix(SearchValueSet): prevent input from losing focus during search #3236

### DIFF
--- a/src/components/SearchValueSet/index.tsx
+++ b/src/components/SearchValueSet/index.tsx
@@ -83,10 +83,7 @@ const SearchValueSet = ({ references, selectedNodes, onSelect }: SearchValueSetP
                   Référentiels :
                 </Typography>
                 <ReferencesParameters
-                  disabled={
-                    loadingStatus.init === LoadingStatus.FETCHING ||
-                    (mode === SearchMode.RESEARCH && loadingStatus.search === LoadingStatus.FETCHING)
-                  }
+                  disabled={loadingStatus.init === LoadingStatus.FETCHING}
                   onSelect={onChangeReferences}
                   type={mode === SearchMode.EXPLORATION ? Type.SINGLE : Type.MULTIPLE}
                   values={refs}
@@ -98,7 +95,6 @@ const SearchValueSet = ({ references, selectedNodes, onSelect }: SearchValueSetP
                     <Input
                       value={searchInput}
                       placeholder="Rechercher un code"
-                      disabled={loadingStatus.search === LoadingStatus.FETCHING}
                       fullWidth
                       onChange={(event) => onChangeSearchInput(event.target.value)}
                       endAdornment={


### PR DESCRIPTION
## Fixes
Fixes [#3226](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3236)

## Description
- Remove disabled prop on search Input when loadingStatus is FETCHING, which was causing the browser to blur the field automatically

