### PR TITLE
ci: clarify publish workflow run names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,8 @@
-name: cohort360-frontend-publish
+name: Publish Docker frontend
+
+run-name: >-
+  Publish Docker frontend - ${{ github.event.workflow_run.head_branch }}
+  - ${{ github.event.workflow_run.display_title }}
 
 on:
   workflow_run:
@@ -11,6 +15,7 @@ on:
 
 jobs:
   publish:
+    name: Build and push frontend Docker image - ${{ github.event.workflow_run.head_branch }}
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
 


### PR DESCRIPTION
## Résumé
- Renomme le workflow de publish Docker frontend avec un libellé humain.
- Ajoute un `run-name` basé sur la branche et le titre du run amont.
- Rend le nom du job Docker plus explicite dans les détails du run.

## Validation
- `npx --yes yaml-lint .github/workflows/publish.yml`
- `git diff --check`

Note: `actionlint` n'était pas disponible localement, et `go` non plus pour le lancer via `go run`.