### PR TITLE
fix(export): clear filter field when unselecting a table

### DIFF
--- a/src/pages/ExportRequest/components/ExportTable/index.tsx
+++ b/src/pages/ExportRequest/components/ExportTable/index.tsx
@@ -451,7 +451,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
                     return `${option.name}`
                   }}
                   renderInput={(params) => <TextField {...params} label="Sélectionnez un filtre" />}
-                  value={tableSetting?.fhirFilter}
+                  value={tableSetting?.fhirFilter ?? null}
                   onChange={(_, value) => {
                     onChangeTableSettings([{ tableName: exportTable.name, key: 'fhirFilter', value }])
                   }}


### PR DESCRIPTION
## Objectif
Dans le formulaire d'export, après avoir sélectionné une table puis un filtre, le fait de décocher la table laissait le filtre affiché visuellement dans son `Autocomplete` alors que le count revenait au total sans filtre

## Changements réalisés
L'`Autocomplete` du filtre passe désormais `value={tableSetting?.fhirFilter ?? null}` au lieu de `value={tableSetting?.fhirFilter}`. Quand la table est désélectionnée, `tableSetting` devient `undefined`, le composant bascule sinon en mode uncontrolled et conserve sa dernière valeur affichée.

Fixes [gestion-de-projet#3149](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3149)