### PR TITLE
fix(request): incorrect-mapping-ultrasoundMonitoring

### DIFF
--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/forms/PregnancyForm.ts
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/forms/PregnancyForm.ts
@@ -222,13 +222,13 @@ export const form: () => CriteriaForm<PregnancyDataType> = () => ({
           type: 'autocomplete',
           label: 'Suivi échographique',
           extraLabel: () => 'Suivi échographique',
-          valueSetId: getConfig().features.questionnaires.valueSets.booleanFields.url,
-          valueSetData: getConfig().features.questionnaires.valueSets.booleanFields.data,
-          noOptionsText: 'Veuillez entrer "oui" ou "non"',
+          valueSetId: getConfig().features.questionnaires.valueSets.ultrasoundMonitoring.url,
+          valueSetData: getConfig().features.questionnaires.valueSets.ultrasoundMonitoring.data,
+          noOptionsText: 'Veuillez entrer une valeur de suivi échographique',
           buildInfo: {
             fhirKey: {
-              id: 'F_MATER_001552',
-              type: 'valueBoolean'
+              id: 'F_MATER_003026',
+              type: 'valueCoding'
             },
             chipDisplayMethodExtraArgs: [{ type: 'string', value: 'Suivi échographique :' }]
           }

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -3,7 +3,13 @@ import { Root } from 'react-dom/client'
 import * as R from 'ramda'
 import { CONFIG_URL } from 'constants.js'
 import { LabelObject } from 'types/searchCriterias'
-import { birthStatusData, booleanFieldsData, booleanOpenChoiceFieldsData, vmeData } from 'data/questionnaire_data'
+import {
+  birthStatusData,
+  booleanFieldsData,
+  booleanOpenChoiceFieldsData,
+  ultrasoundMonitoringData,
+  vmeData
+} from 'data/questionnaire_data'
 
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
@@ -126,6 +132,7 @@ export type AppConfig = {
       risksRelatedToObstetricHistory: ValueSetConfig
       booleanOpenChoiceFields: ValueSetConfig
       booleanFields: ValueSetConfig
+      ultrasoundMonitoring: ValueSetConfig
       vme: ValueSetConfig
       birthStatus: ValueSetConfig
     }> & {
@@ -393,6 +400,10 @@ let config: AppConfig = {
         booleanFields: {
           url: 'booleanFields',
           data: booleanFieldsData
+        },
+        ultrasoundMonitoring: {
+          url: 'ultrasoundMonitoring',
+          data: ultrasoundMonitoringData
         },
         vme: {
           url: 'vme',

--- a/src/data/pregnancyData.ts
+++ b/src/data/pregnancyData.ts
@@ -59,8 +59,8 @@ export const pregnancyForm: {
     type: 'valueBoolean'
   },
   ultrasoundMonitoring: {
-    id: 'F_MATER_001552',
-    type: 'valueBoolean'
+    id: 'F_MATER_003026',
+    type: 'valueCoding'
   },
   pregnancyType: {
     id: 'F_MATER_001024',

--- a/src/data/questionnaire_data.ts
+++ b/src/data/questionnaire_data.ts
@@ -20,6 +20,17 @@ export const booleanFieldsData = [
   }
 ]
 
+export const ultrasoundMonitoringData = [
+  {
+    id: 'Marqué par',
+    label: 'Marqué par'
+  },
+  {
+    id: 'Normal',
+    label: 'Normal'
+  }
+]
+
 export const vmeData = [
   {
     id: 'Non faite',


### PR DESCRIPTION
## Fix
https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/2867

## Objectif
Corriger les problèmes avec le champ ultrasoundMonitoring "Suivi echographique":
- le linkId est incorrect
- le contenu des données qui est faux
- la requête envoyée au FHIR n'utilise pas le bon type

## Changements réalisés
Correction du linkId et du type pour Suivi échographique:
- ultrasoundMonitoring passe de F_MATER_001552 à F_MATER_003026
- type passe de valueBoolean à valueCoding

Correction du formulaire critère grossesse:
- ultrasoundMonitoring utilise maintenant le valueset dédié ultrasoundMonitoring

Déclaration et câblage du nouveau valueset dans la config

## Impacts
Front

## Tests réalisés
manuel

## Risques
Peu de risque: la recherche par Suivi echographique ne fonctionne pas acutellement. Donc le seul risque de cette PR est que cela ne fonctionne toujours pas. Il n'y a pas d'impact sur d'autre fonctionnalité dans l'application
