### PR TITLE
fix(request): wrong-version-number

### DIFF
--- a/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
+++ b/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
@@ -33,6 +33,7 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
   const debouncedValue = useDebounce(debounceMs, editorValue)
 
   const didJsonValueChanged = useRef<boolean>(false)
+  const skipNextEditorChangeRef = useRef<boolean>(false)
 
   const validate = useMemo(() => {
     if (!JsonDefaultSchema) return null
@@ -48,6 +49,8 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
   useEffect(() => {
     if (didInitPrettyRef.current) return
     if (!request.json) return
+
+    skipNextEditorChangeRef.current = true
 
     try {
       setEditorValue(JSON.stringify(JSON.parse(request.json), null, 2))
@@ -114,6 +117,13 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
           value={editorValue}
           onChange={(v) => {
             const next = v ?? ''
+
+            if (skipNextEditorChangeRef.current) {
+              skipNextEditorChangeRef.current = false
+              setEditorValue(next)
+              return
+            }
+
             didJsonValueChanged.current = true
             setEditorValue(next)
             dispatch(editJson(next))

--- a/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
+++ b/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
@@ -24,8 +24,14 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
   const [syntaxError, setSyntaxError] = useState<string | null>(null)
   const [schemaErrors, setSchemaErrors] = useState<string[]>([])
 
-  const [editorValue, setEditorValue] = useState<string>('')
-  const didInitPrettyRef = useRef(false)
+  const [editorValue, setEditorValue] = useState<string>(() => {
+    if (!request.json) return ''
+    try {
+      return JSON.stringify(JSON.parse(request.json), null, 2)
+    } catch {
+      return request.json
+    }
+  })
 
   const editorRef = useRef<any>(null)
   const monacoRef = useRef<any>(null)
@@ -33,7 +39,6 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
   const debouncedValue = useDebounce(debounceMs, editorValue)
 
   const didJsonValueChanged = useRef<boolean>(false)
-  const skipNextEditorChangeRef = useRef<boolean>(false)
 
   const validate = useMemo(() => {
     if (!JsonDefaultSchema) return null
@@ -45,21 +50,6 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
   }, [])
 
   const hasError = Boolean(syntaxError) || schemaErrors.length > 0
-
-  useEffect(() => {
-    if (didInitPrettyRef.current) return
-    if (!request.json) return
-
-    skipNextEditorChangeRef.current = true
-
-    try {
-      setEditorValue(JSON.stringify(JSON.parse(request.json), null, 2))
-    } catch {
-      setEditorValue(request.json)
-    }
-
-    didInitPrettyRef.current = true
-  }, [request.json])
 
   useEffect(() => {
     if (!debouncedValue) {
@@ -114,16 +104,9 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
           height={minHeight}
           language="json"
           theme="vs-dark"
-          value={editorValue}
+          defaultValue={editorValue}
           onChange={(v) => {
             const next = v ?? ''
-
-            if (skipNextEditorChangeRef.current) {
-              skipNextEditorChangeRef.current = false
-              setEditorValue(next)
-              return
-            }
-
             didJsonValueChanged.current = true
             setEditorValue(next)
             dispatch(editJson(next))


### PR DESCRIPTION
## Fix

https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3259   (partie Frontend)

## Objectif
Le numéro de version de la requête est parfois faux. On obtient 1,1,3 au lieu de 1,2,3
L'objectif est de corrigé ce qui déclenche cette mauvaise numérotation

## Changements réalisés
Ajout d'un flag dans l’initialisation de l'éditeur JSON pour que le chargement des données dans l'éditeur ne déclenche pas le dispatch. Seuls les vraies modification utilisateur doivent le déclencher.

## Impacts
Front

## Tests réalisés
manuel, non-régression.

## Risques
Pas de points de vigilances
