### PR TITLE
fix(request): wrong-version-number via uncontrolled Monaco editor

### DIFF
--- a/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
+++ b/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
@@ -24,8 +24,14 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
   const [syntaxError, setSyntaxError] = useState<string | null>(null)
   const [schemaErrors, setSchemaErrors] = useState<string[]>([])
 
-  const [editorValue, setEditorValue] = useState<string>('')
-  const didInitPrettyRef = useRef(false)
+  const [editorValue, setEditorValue] = useState<string>(() => {
+    if (!request.json) return ''
+    try {
+      return JSON.stringify(JSON.parse(request.json), null, 2)
+    } catch {
+      return request.json
+    }
+  })
 
   const editorRef = useRef<any>(null)
   const monacoRef = useRef<any>(null)
@@ -44,19 +50,6 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
   }, [])
 
   const hasError = Boolean(syntaxError) || schemaErrors.length > 0
-
-  useEffect(() => {
-    if (didInitPrettyRef.current) return
-    if (!request.json) return
-
-    try {
-      setEditorValue(JSON.stringify(JSON.parse(request.json), null, 2))
-    } catch {
-      setEditorValue(request.json)
-    }
-
-    didInitPrettyRef.current = true
-  }, [request.json])
 
   useEffect(() => {
     if (!debouncedValue) {
@@ -111,7 +104,7 @@ const JsonView: React.FC<JsonEditorWithAjvProps> = ({ onJsonIssuesChange, minHei
           height={minHeight}
           language="json"
           theme="vs-dark"
-          value={editorValue}
+          defaultValue={editorValue}
           onChange={(v) => {
             const next = v ?? ''
             didJsonValueChanged.current = true


### PR DESCRIPTION
Le MonacoEditor était contrôlé via `value`, ce qui faisait que la mise à jour programmatique initiale (pretty-print) déclenchait un `onChange` interprété comme une édition utilisateur, donc un dispatch et un snapshot dupliqué côté back. Passage en `defaultValue` : l'éditeur n'est plus contrôlé après le mount, donc plus de onChange parasite à l'init.

## Objectif
Quel problème est traité ?

## Changements réalisés
Résumé technique clair.

## Impacts
Front / Back / API / DB / sécurité / performance / droits / exports / jobs.

## Tests réalisés
Unitaires, intégration, manuel, non-régression.

## Risques
Ce qui peut casser, points de vigilance.
