### PR TITLE
fix(cohortCreation): guard saveJson against concurrent dispatches (#3259)

### DIFF
--- a/src/state/cohortCreation.ts
+++ b/src/state/cohortCreation.ts
@@ -27,6 +27,10 @@ import { Hierarchy } from 'types/hierarchy'
 import { getConfig } from 'config'
 import { ScopeElement } from 'types/scope'
 
+// `unwrap()` rethrows this error name when an async thunk skips execution via its `condition` option.
+const isThunkConditionAbort = (e: unknown): boolean =>
+  typeof e === 'object' && e !== null && (e as { name?: unknown }).name === 'ConditionError'
+
 /**
  * State interface for cohort creation functionality.
  * Contains all data needed for building and managing cohort requests.
@@ -343,6 +347,11 @@ const saveJson = createAsyncThunk<SaveJsonReturn, SaveJsonParams, { state: RootS
       console.error(error)
       throw error
     }
+  },
+  {
+    // gestion-de-projet#3259: concurrent saveJson dispatches race and both POST
+    // as firstTime=true, producing snapshots with duplicate version numbers.
+    condition: (_, { getState }) => !getState().cohortCreation.request.saveLoading
   }
 )
 
@@ -394,14 +403,20 @@ const buildCohortCreation = createAsyncThunk<BuildCohortReturn, BuildCohortParam
 
       const json = buildRequest(_selectedPopulation, _selectedCriteria, _criteriaGroup, _temporalConstraints)
       if (json !== state?.cohortCreation?.request?.json) {
-        const saveJsonResponse = await dispatch(saveJson({ newJson: json })).unwrap()
-        await dispatch(
-          countCohortCreation({
-            json: json,
-            snapshotId: saveJsonResponse.currentSnapshot.uuid,
-            requestId: saveJsonResponse.requestId
-          })
-        )
+        try {
+          const saveJsonResponse = await dispatch(saveJson({ newJson: json })).unwrap()
+          await dispatch(
+            countCohortCreation({
+              json: json,
+              snapshotId: saveJsonResponse.currentSnapshot.uuid,
+              requestId: saveJsonResponse.requestId
+            })
+          )
+        } catch (e) {
+          // Swallow the abort when saveJson's condition skipped the dispatch;
+          // the in-flight save will finalize the snapshot.
+          if (!isThunkConditionAbort(e)) throw e
+        }
       }
 
       const allowSearchIpp = _selectedPopulation ? await services.perimeters.allowSearchIpp(_selectedPopulation) : false


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3259

Suite à la PR 1239 (mergée) qui visait le mauvais coupable : la duplication du POST `/request-query-snapshots/` vient d'une race entre deux `buildCohortCreation` lors de la création d'une nouvelle requête, pas de `JsonView`. Le patch backend (PR Back 525) absorbe le bug user-visible, mais le front fait toujours un POST inutile qui revient en 400 silencieuse.

## Changements réalisés
- Option `condition` sur le thunk `saveJson` : si `saveLoading` est déjà à `true`, le second dispatch est court-circuité (ni `.pending` ni `.fulfilled` ne fire).
- `buildCohortCreation` swallow l'erreur `ConditionError` levée par `unwrap()` quand son `saveJson` est court-circuité, pour laisser le save in-flight finaliser le snapshot.
- Helper `isThunkConditionAbort` pour identifier proprement l'abort.

## Impacts
Front uniquement. Couvre toutes les sources de double-dispatch présentes et futures (cf. `.map()` dans `TemporalConstraintCard.tsx:48`, futur bug latent du même genre).

## Tests réalisés
Manuel : scénario "nouvelle requête" → un seul POST `/request-query-snapshots/` au lieu de deux, plus de 400 dans la console.
Non-régression : navigation logical ↔ JSON, save sur edit, ajout/suppression de critères.

## Risques
Si un autre thunk dispatche `saveJson` avec un nouveau contenu pile pendant qu'un save différent est en cours, le second est silencieusement skip. La prochaine action utilisateur déclenchera `buildCohortCreation` qui re-comparera et re-savera si nécessaire, donc pas de perte définitive. À surveiller sur le flow `addRequestToCohortCreation` qui dispatch `saveJson` directement.