### PR TITLE
fix(json): self-host Monaco editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,8 @@
         "redux-persist": "^6.0.0",
         "redux-state-sync": "^3.1.4",
         "tss-react": "^4.9.19",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "monaco-editor": "^0.55.1"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.0.1",
@@ -11375,7 +11376,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "redux-persist": "^6.0.0",
     "redux-state-sync": "^3.1.4",
     "tss-react": "^4.9.19",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "monaco-editor": "^0.55.1"
   },
   "overrides": {
     "nth-check": "2.1.1",

--- a/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
+++ b/src/components/CreationCohort/DiagramView/components/JsonView/index.tsx
@@ -1,6 +1,7 @@
 import { useAppDispatch, useAppSelector } from 'state'
 
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import './monacoSetup'
 import MonacoEditor, { type OnMount } from '@monaco-editor/react'
 import 'monaco-editor/esm/vs/language/json/monaco.contribution'
 import Ajv from 'ajv'

--- a/src/components/CreationCohort/DiagramView/components/JsonView/monacoSetup.ts
+++ b/src/components/CreationCohort/DiagramView/components/JsonView/monacoSetup.ts
@@ -5,7 +5,7 @@ import { loader } from '@monaco-editor/react'
 
 // Self-host Monaco: empêche @monaco-editor/loader de fetch cdn.jsdelivr.net
 // (egress bloqué dans les pods k8s APHP -> editor jamais initialisé en CI/prod).
-;(self as unknown as { MonacoEnvironment: monaco.Environment }).MonacoEnvironment = {
+;(globalThis as unknown as { MonacoEnvironment: monaco.Environment }).MonacoEnvironment = {
   getWorker(_workerId, label) {
     if (label === 'json') return new jsonWorker()
     return new editorWorker()

--- a/src/components/CreationCohort/DiagramView/components/JsonView/monacoSetup.ts
+++ b/src/components/CreationCohort/DiagramView/components/JsonView/monacoSetup.ts
@@ -1,0 +1,15 @@
+import * as monaco from 'monaco-editor'
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+import { loader } from '@monaco-editor/react'
+
+// Self-host Monaco: empêche @monaco-editor/loader de fetch cdn.jsdelivr.net
+// (egress bloqué dans les pods k8s APHP -> editor jamais initialisé en CI/prod).
+;(self as unknown as { MonacoEnvironment: monaco.Environment }).MonacoEnvironment = {
+  getWorker(_workerId, label) {
+    if (label === 'json') return new jsonWorker()
+    return new editorWorker()
+  }
+}
+
+loader.config({ monaco })


### PR DESCRIPTION
Fixes [ID/design-et-produit/ipa/cohort360/gestion-de-projet#3188 (closed)](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3188)

## Objectif
L'éditeur JSON du requêteur charge Monaco via `@monaco-editor/loader`, qui fetch `cdn.jsdelivr.net` au runtime. Cette CDN n'est pas joignable depuis les pods k8s APHP : l'egress laisse passer le SYN/ACK puis drop le TLS handshake. L'editor ne s'initialise donc jamais, `role="code"` n'est jamais posé sur le `.monaco-editor`, et le TNR `CriteresJson` (step `L'interface json s'affiche`) timeout 100% en CI. Probable que la prod/preprod en pâtissent aussi côté navigateurs sans accès libre à jsdelivr.

## Changements réalisés
`monaco-editor` passe en dep directe (il était déjà installé transitivement par `@monaco-editor/react`). Un nouveau `JsonView/monacoSetup.ts` configure `MonacoEnvironment.getWorker` via les `?worker` imports de Vite et appelle `loader.config({ monaco })` : `@monaco-editor/loader` consomme alors l'instance locale au lieu d'aller la chercher en CDN. Importé en side-effect en tête de `JsonView/index.tsx` pour que la conf soit posée avant le premier mount.

Vite bundle désormais `editor.worker`, `json.worker`, `css.worker`, `html.worker`, `ts.worker` dans `build/assets/` — plus aucun fetch externe à runtime.

## Impacts
Front uniquement. Pas de changement de version Monaco (0.55.1, identique à celle qui était servie par jsdelivr). Surcoût bundle limité aux workers Monaco.

## Tests réalisés
- \`tsc --noEmit\` OK
- \`vite build\` OK, workers présents dans \`build/assets/\`
- À rejouer une fois déployé en qualif : TNR \`CriteresJson\` côté [front-e2e](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/dev/integration-tests/front-e2e)

## Risques
La conf `loader.config({ monaco })` est globale et idempotente. Si la prod/preprod tournait jusqu'ici en s'appuyant silencieusement sur la CDN externe, ce MR retire cette dépendance.