### PR TITLE
ci: use updated SonarCloud token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Check Sonar token availability
         id: check
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_NEW }}
         run: |
           if [ -n "$SONAR_TOKEN" ]; then
             echo "has_sonar_token=true" >> "$GITHUB_OUTPUT"
@@ -166,7 +166,7 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_NEW }}
         with:
           args: >
             -Dsonar.projectVersion=${{ env.VERSION }}


### PR DESCRIPTION
﻿## Résumé

- Remplace l'ancien secret `SONAR_TOKEN` par `SONAR_TOKEN_NEW` dans le precheck Sonar.
- Utilise `SONAR_TOKEN_NEW` pour le job `SonarCloud Scan`.

## Pourquoi

Le run de release `3.5.0` échouait avec un `403 Forbidden` SonarCloud en utilisant l'ancien `SONAR_TOKEN`. Le même changement appliqué sur `release/3.5.0` a rendu le workflow vert.

## Validation

- Run release vérifié : https://github.com/aphp/Cohort360-FrontEnd/actions/runs/27148528572
