### PR TITLE
fix(exploration): add _text deleted

### DIFF
--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -397,15 +397,16 @@ export const fetchDocumentReference = async (
     options = [...options, `${DocumentsParamsKeys.DOC_TYPES}=${typeCodesWithParents.join(',')}`]
   }
   if (_text)
-    if (highlight_search_results)
-      options = [
-        ...options,
-        `${
-          searchBy === SearchByTypes.TEXT
-            ? `_tag=${encodeURIComponent('https://terminology.eds.aphp.fr/misc|HIGHLIGHT_RESULTS')}`
-            : ''
-        }`
-      ]
+    options = [...options, `${searchBy === SearchByTypes.TEXT ? '_text' : 'description'}=${encodeURIComponent(_text)}`]
+  if (_text && highlight_search_results)
+    options = [
+      ...options,
+      `${
+        searchBy === SearchByTypes.TEXT
+          ? `_tag=${encodeURIComponent('https://terminology.eds.aphp.fr/misc|HIGHLIGHT_RESULTS')}`
+          : ''
+      }`
+    ]
   if (docStatuses && docStatuses.length > 0) {
     const docStatusesUrl = docStatusCodeSystem
     const urlString = docStatuses


### PR DESCRIPTION
## Objectif
fix: https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/2829

Le paramètre_text n'était plus envoyé à l'API Fhir. Il avait été supprimé par erreur

## Changements réalisés
Remise en place de l'envoi du paramètre_text

## Impacts
Front 

## Tests réalisés
manuel, non-régression.

## Risques
Pas de points de vigilance
