### PR TITLE
feat(exploration): use diagnostic report

### DIFF
--- a/src/__tests__/components/ExplorationBoard/config/imaging.test.ts
+++ b/src/__tests__/components/ExplorationBoard/config/imaging.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { DiagnosticReport, ImagingStudy } from 'fhir/r4'
+import { CellType } from 'types/table'
+import { Direction, Order } from 'types/searchCriterias'
+
+vi.mock('config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('config')>()
+  return {
+    ...actual,
+    getConfig: vi.fn(() => ({
+      ...actual.getConfig(),
+      core: {
+        ...actual.getConfig().core,
+        valueSets: {
+          ...actual.getConfig().core.valueSets,
+          encounterStatus: { url: 'vs-encounter-status' }
+        }
+      },
+      features: {
+        ...actual.getConfig().features,
+        imaging: {
+          ...actual.getConfig().features.imaging,
+          valueSets: {
+            ...actual.getConfig().features.imaging.valueSets,
+            imagingModalities: { url: 'vs-imaging-modalities' }
+          },
+          extensions: {
+            ...actual.getConfig().features.imaging.extensions,
+            seriesProtocolUrl: 'series-protocol-url'
+          }
+        }
+      }
+    }))
+  }
+})
+
+vi.mock('services/aphp/callApi', () => ({
+  fetchImaging: vi.fn()
+}))
+
+vi.mock('services/aphp/serviceValueSets', () => ({
+  getCodeList: vi.fn()
+}))
+
+vi.mock('services/aphp/serviceImaging', () => ({
+  linkToDiagnosticReport: vi.fn()
+}))
+
+vi.mock('utils/exploration', () => ({
+  fetcherWithParams: vi.fn(),
+  fetchValueSet: vi.fn(),
+  getCommonParamsAll: vi.fn(() => ({ size: 0 })),
+  getCommonParamsList: vi.fn(() => ({ size: 10, offset: 0, _sort: 'started', sortDirection: 'desc' })),
+  narrowSearchCriterias: vi.fn((_, criterias) => criterias),
+  resolveAdditionalInfos: vi.fn(async () => ({}))
+}))
+
+vi.mock('utils/fhir', () => ({
+  getExtension: vi.fn()
+}))
+
+import { imagingConfig } from 'components/ExplorationBoard/config/imaging'
+import { fetcherWithParams } from 'utils/exploration'
+import { linkToDiagnosticReport } from 'services/aphp/serviceImaging'
+
+const mockFetcherWithParams = vi.mocked(fetcherWithParams)
+const mockLinkToDiagnosticReport = vi.mocked(linkToDiagnosticReport)
+
+const makeImagingStudy = (id: string, patientId = 'p1'): ImagingStudy => ({
+  resourceType: 'ImagingStudy',
+  id,
+  status: 'available',
+  subject: { reference: `Patient/${patientId}` }
+})
+
+describe('imaging config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('enrichit la liste avec linkToDiagnosticReport dans fetchList', async () => {
+    const rawList: ImagingStudy[] = [makeImagingStudy('study-1')]
+    const linkedList: ImagingStudy[] = [{ ...makeImagingStudy('study-1'), description: 'linked' }]
+
+    mockFetcherWithParams.mockResolvedValue({
+      total: 1,
+      totalAllResults: 1,
+      totalPatients: 1,
+      totalAllPatients: 1,
+      list: rawList
+    } as never)
+
+    mockLinkToDiagnosticReport.mockResolvedValue(linkedList as never)
+
+    const config = imagingConfig(false, null, [])
+
+    const result = await config.fetchList!(
+      {
+        size: 10,
+        page: 1,
+        searchInput: '',
+        orderBy: { orderBy: Order.STUDY_DATE, orderDirection: Direction.DESC },
+        includeFacets: false
+      },
+      {
+        filters: {
+          ipp: '',
+          nda: '',
+          modality: [],
+          bodySite: '',
+          durationRange: [null, null],
+          executiveUnits: [],
+          encounterStatus: []
+        }
+      }
+    )
+
+    expect(mockLinkToDiagnosticReport).toHaveBeenCalledWith(rawList, undefined)
+    expect(result.list).toEqual(linkedList)
+  })
+
+  it('extrait correctement l id Binary depuis presentedForm.url avec query/hash', () => {
+    const diagnosticReport: DiagnosticReport = {
+      resourceType: 'DiagnosticReport',
+      status: 'final',
+      code: { text: 'CR' },
+      presentedForm: [{ contentType: 'application/pdf', url: 'https://fhir.local/Binary/pdf-123?dl=1#anchor' }]
+    }
+
+    const config = imagingConfig(false, null, [])
+    const table = config.mapToTable!({
+      total: 1,
+      totalAllResults: 1,
+      totalPatients: 1,
+      totalAllPatients: 1,
+      list: [
+        {
+          ...makeImagingStudy('study-1'),
+          idPatient: 'patient-1',
+          IPP: 'IPP-1',
+          NDA: 'NDA-1',
+          diagnosticReport,
+          series: []
+        } as never
+      ]
+    })
+
+    const documentCell = table.rows[0].find((cell) => cell.type === CellType.DOCUMENT_VIEWER)
+
+    expect(documentCell).toBeDefined()
+    expect((documentCell?.value as { id: string }).id).toBe('pdf-123')
+  })
+})

--- a/src/__tests__/services/serviceImaging.test.ts
+++ b/src/__tests__/services/serviceImaging.test.ts
@@ -1,0 +1,148 @@
+import { AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import { DiagnosticReport, ImagingStudy } from 'fhir/r4'
+import { getConfig, type AppConfig } from 'config'
+import { FHIR_Bundle_Response } from 'types'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('config', () => ({
+  getConfig: vi.fn()
+}))
+
+vi.mock('services/aphp/callApi', () => ({
+  fetchDiagnosticReport: vi.fn()
+}))
+
+import { fetchDiagnosticReport } from 'services/aphp/callApi'
+import { linkToDiagnosticReport } from 'services/aphp/serviceImaging'
+
+const mockGetConfig = vi.mocked(getConfig)
+const mockFetchDiagnosticReport = vi.mocked(fetchDiagnosticReport)
+
+let baseConfig: Readonly<AppConfig>
+
+const buildDiagnosticReportConfig = (enabled: boolean, useStudyParam: boolean): Readonly<AppConfig> => ({
+  ...baseConfig,
+  features: {
+    ...baseConfig.features,
+    diagnosticReport: {
+      ...baseConfig.features.diagnosticReport,
+      enabled,
+      useStudyParam
+    }
+  }
+})
+
+const axiosConfig: InternalAxiosRequestConfig = {
+  headers: new AxiosHeaders(),
+  method: 'post',
+  url: '/DiagnosticReport/_search'
+}
+
+const buildBundleResponse = (reports: DiagnosticReport[]): AxiosResponse<FHIR_Bundle_Response<DiagnosticReport>> => ({
+  data: {
+    resourceType: 'Bundle',
+    type: 'searchset',
+    entry: reports.map((resource) => ({ resource }))
+  },
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: axiosConfig
+})
+
+const makeImagingStudy = (id: string, patientId = 'p1'): ImagingStudy => ({
+  resourceType: 'ImagingStudy',
+  id,
+  status: 'available',
+  subject: { reference: `Patient/${patientId}` }
+})
+
+describe('serviceImaging.linkToDiagnosticReport', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const actualConfigModule = await vi.importActual<typeof import('config')>('config')
+    baseConfig = actualConfigModule.getConfig()
+  })
+
+  it('retourne la liste telle quelle quand la feature est désactivée', async () => {
+    mockGetConfig.mockReturnValue(buildDiagnosticReportConfig(false, false))
+
+    const imagingList: ImagingStudy[] = [makeImagingStudy('study-1')]
+
+    const result = await linkToDiagnosticReport(imagingList)
+
+    expect(result).toEqual(imagingList)
+    expect(mockFetchDiagnosticReport).not.toHaveBeenCalled()
+  })
+
+  it('utilise le paramètre study quand useStudyParam est activé', async () => {
+    mockGetConfig.mockReturnValue(buildDiagnosticReportConfig(true, true))
+
+    mockFetchDiagnosticReport.mockResolvedValue(buildBundleResponse([]))
+
+    const imagingList: ImagingStudy[] = [makeImagingStudy('study-1', 'p1'), makeImagingStudy('study-2', 'p2')]
+
+    await linkToDiagnosticReport(imagingList)
+
+    expect(mockFetchDiagnosticReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        study: ['study-1', 'study-2']
+      })
+    )
+    expect(mockFetchDiagnosticReport).toHaveBeenCalledWith(
+      expect.not.objectContaining({ patient: expect.anything() })
+    )
+  })
+
+  it('utilise le paramètre patient (dédupliqué) quand useStudyParam est désactivé', async () => {
+    mockGetConfig.mockReturnValue(buildDiagnosticReportConfig(true, false))
+
+    mockFetchDiagnosticReport.mockResolvedValue(buildBundleResponse([]))
+
+    const imagingList: ImagingStudy[] = [
+      makeImagingStudy('study-1', 'p1'),
+      makeImagingStudy('study-2', 'p1'),
+      makeImagingStudy('study-3', 'p2')
+    ]
+
+    await linkToDiagnosticReport(imagingList)
+
+    expect(mockFetchDiagnosticReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patient: ['p1', 'p2']
+      })
+    )
+    expect(mockFetchDiagnosticReport).toHaveBeenCalledWith(
+      expect.not.objectContaining({ study: expect.anything() })
+    )
+  })
+
+  it('associe les reports par imagingStudy.reference et privilégie celui qui a un PDF', async () => {
+    mockGetConfig.mockReturnValue(buildDiagnosticReportConfig(true, false))
+
+    const reportWithoutPdf: DiagnosticReport = {
+      resourceType: 'DiagnosticReport',
+      status: 'final',
+      code: { text: 'CR sans PDF' },
+      imagingStudy: [{ reference: 'ImagingStudy/study-1' }],
+      presentedForm: [{ contentType: 'text/plain', url: 'Binary/no-pdf' }]
+    }
+
+    const reportWithPdf: DiagnosticReport = {
+      resourceType: 'DiagnosticReport',
+      status: 'final',
+      code: { text: 'CR avec PDF' },
+      imagingStudy: [{ reference: 'ImagingStudy/study-1' }],
+      presentedForm: [{ contentType: 'application/pdf', url: 'Binary/pdf-1' }]
+    }
+
+    mockFetchDiagnosticReport.mockResolvedValue(buildBundleResponse([reportWithoutPdf, reportWithPdf]))
+
+    const imagingList: ImagingStudy[] = [makeImagingStudy('study-1', 'p1'), makeImagingStudy('study-2', 'p1')]
+
+    const result = await linkToDiagnosticReport(imagingList)
+
+    expect(result[0].diagnosticReport).toEqual(reportWithPdf)
+    expect(result[1].diagnosticReport).toBeUndefined()
+  })
+})

--- a/src/components/ExplorationBoard/config/imaging.ts
+++ b/src/components/ExplorationBoard/config/imaging.ts
@@ -3,6 +3,7 @@ import { plural } from 'utils/string'
 import { ImagingStudy, ImagingStudySeries } from 'fhir/r4'
 import { mapToDate } from 'mappers/dates'
 import { fetchImaging } from 'services/aphp/callApi'
+import { linkToDiagnosticReport } from 'services/aphp/serviceImaging'
 import { getCodeList } from 'services/aphp/serviceValueSets'
 import { CohortImaging } from 'types'
 import {
@@ -128,6 +129,12 @@ const mapImagingSeries = (series: ImagingStudySeries[]): Table => {
   }
 }
 
+const extractBinaryIdFromUrl = (url?: string) => {
+  if (!url) return undefined
+  const sanitizedUrl = url.split('?')[0].split('#')[0]
+  return sanitizedUrl.split('/').pop()
+}
+
 const mapToTable = (data: Data, deidentified: boolean, isPatient: boolean, groupId: string[]): Table => {
   const rows: Row[] = []
   const columns: Column[] = [
@@ -151,12 +158,10 @@ const mapToTable = (data: Data, deidentified: boolean, isPatient: boolean, group
     const nbSeries = elem.numberOfSeries ?? '-'
     const accessNumber =
       elem.identifier?.find((identifier) => identifier.system?.includes('accessNumber'))?.value ?? '-'
-    // TODO remove the fetch by extension when fhir drop it (expected in 2.21.0 or 2.22.0)
     const documentId = elem.diagnosticReport
-      ? elem.diagnosticReport.presentedForm
-          ?.find((el) => el.contentType === 'application/pdf')
-          ?.url?.split('/')
-          .pop()
+      ? extractBinaryIdFromUrl(
+          elem.diagnosticReport.presentedForm?.find((el) => el.contentType === 'application/pdf')?.url
+        )
       : getExtension(elem, 'docId')?.valueString
     const ippGroupQuery = groupId ? `?groupId=${groupId}` : ''
     const row: Row = [
@@ -268,7 +273,10 @@ const fetchList = (
     () => fetchImaging(params),
     () => fetchImaging(paramsFetchAll),
     { ...fetchParams, filters, deidentified, patient, groupId }
-  )
+  ).then(async (results) => ({
+    ...results,
+    list: (await linkToDiagnosticReport(results.list as ImagingStudy[], signal)) as ImagingStudy[]
+  }))
 }
 
 export const imagingConfig = (

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -285,7 +285,7 @@ let config: AppConfig = {
       useNDA: true
     },
     diagnosticReport: {
-      enabled: false,
+      enabled: true,
       useStudyParam: false
     },
     export: {

--- a/src/services/aphp/serviceImaging.ts
+++ b/src/services/aphp/serviceImaging.ts
@@ -2,26 +2,78 @@ import { getConfig } from 'config'
 import { CohortImaging } from 'types'
 import { getApiResponseResources } from 'utils/apiHelpers'
 import { fetchDiagnosticReport } from './callApi'
-import { ImagingStudy } from 'fhir/r4'
+import { DiagnosticReport, ImagingStudy } from 'fhir/r4'
+
+// Extract Patient id from references like Patient/{id}.
+const getPatientIdFromReference = (reference?: string) => {
+  if (!reference) return undefined
+  const match = reference.match(/Patient\/([^/]+)/)
+  return match?.[1]
+}
+
+// Extract ImagingStudy id from references like ImagingStudy/{id}.
+const getStudyIdFromReference = (reference?: string) => {
+  if (!reference) return undefined
+  const match = reference.match(/ImagingStudy\/([^/]+)/)
+  return match?.[1]
+}
+
+// Prefer reports that expose an actual PDF attachment url.
+const hasPdfInPresentedForm = (report?: DiagnosticReport) =>
+  !!report?.presentedForm?.some((attachment) => attachment.contentType === 'application/pdf' && !!attachment.url)
 
 export const linkToDiagnosticReport = async (
   imagingList: ImagingStudy[],
   signal?: AbortSignal
 ): Promise<CohortImaging[]> => {
   const config = getConfig()
-  if (!config.features.diagnosticReport.enabled || !config.features.diagnosticReport.useStudyParam) {
+
+  // Fast exit when feature is off or there is no study to enrich.
+  if (!config.features.diagnosticReport.enabled || imagingList.length === 0) {
     return Promise.resolve(imagingList)
   }
-  const diagnosticReports = getApiResponseResources(
-    await fetchDiagnosticReport({
-      study: imagingList.map((study) => study.id as string),
-      signal
-    })
-  )
+
+  const studyIds = imagingList.map((study) => study.id).filter((id): id is string => !!id)
+  const patientIds = [
+    ...new Set(
+      imagingList.map((study) => getPatientIdFromReference(study.subject?.reference)).filter((id): id is string => !!id)
+    )
+  ]
+
+  // Two modes:
+  // - useStudyParam=true: query DiagnosticReport by study ids
+  // - useStudyParam=false: standard R4 fallback, query by patient ids then filter client-side
+  const useStudyParam = config.features.diagnosticReport.useStudyParam && studyIds.length > 0
+  const diagnosticReportArgs = {
+    signal,
+    ...(useStudyParam ? { study: studyIds } : {}),
+    ...(!useStudyParam ? { patient: patientIds } : {})
+  }
+
+  // Nothing to query means no possible enrichment.
+  if (!diagnosticReportArgs.study && !diagnosticReportArgs.patient) {
+    return Promise.resolve(imagingList)
+  }
+
+  const diagnosticReports = getApiResponseResources(await fetchDiagnosticReport(diagnosticReportArgs))
+
+  // Build an index by ImagingStudy id for O(1) lookup during final mapping.
+  const reportByStudyId = new Map<string, DiagnosticReport>()
+  for (const report of diagnosticReports ?? []) {
+    for (const imagingStudyRef of report.imagingStudy ?? []) {
+      const studyId = getStudyIdFromReference(imagingStudyRef.reference)
+      if (!studyId) continue
+
+      const previous = reportByStudyId.get(studyId)
+      // If multiple reports match the same study, keep the one that provides a PDF.
+      if (!previous || (!hasPdfInPresentedForm(previous) && hasPdfInPresentedForm(report))) {
+        reportByStudyId.set(studyId, report)
+      }
+    }
+  }
+
   return imagingList.map((imaging) => ({
     ...imaging,
-    diagnosticReport: diagnosticReports?.find((report) =>
-      report.imagingStudy?.find((study) => study.reference === `ImagingStudy/${imaging.id}`)
-    )
+    diagnosticReport: imaging.id ? reportByStudyId.get(imaging.id) : undefined
   }))
 }


### PR DESCRIPTION
## Objectif

fix: https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3239

Le ticket traite l’accès au compte-rendu PDF d’une ImagingStudy via DiagnosticReport en mode standard FHIR R4, sans dépendre d’un search param non standard côté serveur.

## Changements réalisés

Activation effective du chaînage DiagnosticReport dans le flux Imagerie

## Impacts
Front

## Tests réalisés
Unitaires, manuel, non-régression.

## Risques
Pas de points de vigilance.
