### PR TITLE
fix(requeteur): reconcile count via polling

### DIFF
--- a/src/components/CreationCohort/ControlPanel/ControlPanel.tsx
+++ b/src/components/CreationCohort/ControlPanel/ControlPanel.tsx
@@ -66,6 +66,7 @@ import { AppConfig } from 'config'
 import { setRequestDetailedMode } from 'state/preferences'
 import { hasStageDetails } from '../DiagramView/components/CriteriaCount'
 import { isRequestFinished } from './utils'
+import { useCountReconciliation } from './useCountReconciliation'
 import { CriteriaType } from 'types/requestCriterias'
 
 const ControlPanel: React.FC<{
@@ -242,6 +243,8 @@ const ControlPanel: React.FC<{
       setReportError(true)
     }
   }
+
+  useCountReconciliation(count)
 
   const isLoading = loading || countLoading === LoadingStatus.FETCHING || saveLoading
   const errorCriteria = selectedCriteria.filter((criteria) => criteria.error)

--- a/src/components/CreationCohort/ControlPanel/__tests__/useCountReconciliation.test.ts
+++ b/src/components/CreationCohort/ControlPanel/__tests__/useCountReconciliation.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import { type CohortCount, JobStatus } from 'types'
+import {
+  useCountReconciliation,
+  POLL_INTERVAL_MS,
+  STUCK_TIMEOUT_MS
+} from '../useCountReconciliation'
+
+const mockDispatch = vi.fn()
+const mockCountCohort = vi.fn()
+
+vi.mock('state', () => ({
+  useAppDispatch: () => mockDispatch
+}))
+
+vi.mock('state/cohortCreation', () => ({
+  updateCount: (payload: unknown) => ({ type: 'cohortCreation/updateCount', payload })
+}))
+
+vi.mock('services/aphp', () => ({
+  default: {
+    cohortCreation: {
+      countCohort: (...args: unknown[]) => mockCountCohort(...args)
+    }
+  }
+}))
+
+const advance = (ms: number) => vi.advanceTimersByTimeAsync(ms)
+
+describe('useCountReconciliation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockDispatch.mockClear()
+    mockCountCohort.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not poll when count is undefined', async () => {
+    renderHook(() => useCountReconciliation(undefined))
+    await advance(POLL_INTERVAL_MS * 2)
+    expect(mockCountCohort).not.toHaveBeenCalled()
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('does not poll when status is already terminal', async () => {
+    const count: CohortCount = { uuid: 'dm-1', status: JobStatus.FINISHED }
+    renderHook(() => useCountReconciliation(count))
+    await advance(POLL_INTERVAL_MS * 2)
+    expect(mockCountCohort).not.toHaveBeenCalled()
+  })
+
+  it('polls while status is non-terminal and dispatches updateCount on terminal transition', async () => {
+    const count: CohortCount = { uuid: 'dm-1', status: JobStatus.STARTED }
+    mockCountCohort
+      .mockResolvedValueOnce({ uuid: 'dm-1', status: JobStatus.STARTED })
+      .mockResolvedValueOnce({
+        uuid: 'dm-1',
+        status: JobStatus.FINISHED,
+        includePatient: 42,
+        extra: { foo: 'bar' },
+        snapshotId: 'snap-1'
+      })
+
+    renderHook(() => useCountReconciliation(count))
+
+    await advance(POLL_INTERVAL_MS)
+    expect(mockCountCohort).toHaveBeenCalledTimes(1)
+    expect(mockCountCohort).toHaveBeenLastCalledWith(undefined, undefined, undefined, 'dm-1')
+    expect(mockDispatch).not.toHaveBeenCalled()
+
+    await advance(POLL_INTERVAL_MS)
+    expect(mockCountCohort).toHaveBeenCalledTimes(2)
+    expect(mockDispatch).toHaveBeenCalledTimes(1)
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'cohortCreation/updateCount',
+      payload: {
+        status: JobStatus.FINISHED,
+        includePatient: 42,
+        jobFailMsg: undefined,
+        extra: { foo: 'bar' },
+        snapshotId: 'snap-1'
+      }
+    })
+  })
+
+  it('marks count as errored after STUCK_TIMEOUT_MS without terminal transition', async () => {
+    const count: CohortCount = { uuid: 'dm-stuck', status: JobStatus.STARTED }
+    mockCountCohort.mockResolvedValue({ uuid: 'dm-stuck', status: JobStatus.STARTED })
+
+    renderHook(() => useCountReconciliation(count))
+
+    const ticksBeforeBail = Math.floor(STUCK_TIMEOUT_MS / POLL_INTERVAL_MS)
+    for (let i = 0; i < ticksBeforeBail - 1; i++) {
+      await advance(POLL_INTERVAL_MS)
+    }
+    expect(mockDispatch).not.toHaveBeenCalled()
+
+    await advance(POLL_INTERVAL_MS)
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1)
+    const action = mockDispatch.mock.calls[0][0]
+    expect(action.type).toBe('cohortCreation/updateCount')
+    expect(action.payload.status).toBe('error')
+    expect(action.payload.jobFailMsg).toMatch(/moteur de calcul/)
+  })
+
+  it('stops polling and resets stuck timer when uuid changes', async () => {
+    const first: CohortCount = { uuid: 'dm-1', status: JobStatus.STARTED }
+    const second: CohortCount = { uuid: 'dm-2', status: JobStatus.STARTED }
+
+    mockCountCohort.mockResolvedValue({ status: JobStatus.STARTED })
+
+    const { rerender } = renderHook((c: CohortCount) => useCountReconciliation(c), {
+      initialProps: first
+    })
+
+    const ticksBeforeBail = Math.floor(STUCK_TIMEOUT_MS / POLL_INTERVAL_MS)
+    for (let i = 0; i < ticksBeforeBail - 2; i++) {
+      await advance(POLL_INTERVAL_MS)
+    }
+
+    rerender(second)
+
+    for (let i = 0; i < ticksBeforeBail - 1; i++) {
+      await advance(POLL_INTERVAL_MS)
+    }
+
+    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockCountCohort).toHaveBeenLastCalledWith(undefined, undefined, undefined, 'dm-2')
+  })
+
+  it('swallows transient network errors and keeps polling', async () => {
+    const count: CohortCount = { uuid: 'dm-1', status: JobStatus.STARTED }
+    mockCountCohort
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ status: JobStatus.FINISHED, includePatient: 7 })
+
+    renderHook(() => useCountReconciliation(count))
+
+    await advance(POLL_INTERVAL_MS)
+    expect(mockDispatch).not.toHaveBeenCalled()
+
+    await advance(POLL_INTERVAL_MS)
+    expect(mockDispatch).toHaveBeenCalledTimes(1)
+    expect(mockDispatch.mock.calls[0][0].payload.status).toBe(JobStatus.FINISHED)
+  })
+})

--- a/src/components/CreationCohort/ControlPanel/useCountReconciliation.ts
+++ b/src/components/CreationCohort/ControlPanel/useCountReconciliation.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react'
+
+import services from 'services/aphp'
+import { useAppDispatch } from 'state'
+import { updateCount } from 'state/cohortCreation'
+import { type CohortCount, JobStatus } from 'types'
+
+export const POLL_INTERVAL_MS = 30_000
+export const STUCK_TIMEOUT_MS = 10 * 60_000
+
+const NON_TERMINAL_STATUSES = new Set<string>([
+  JobStatus.NEW,
+  JobStatus.PENDING,
+  JobStatus.STARTED,
+  JobStatus.LONG_PENDING
+])
+
+export const useCountReconciliation = (count: CohortCount | undefined): void => {
+  const dispatch = useAppDispatch()
+  const stuckSinceRef = useRef<{ uuid: string; at: number } | null>(null)
+
+  useEffect(() => {
+    const uuid = count?.uuid
+    const status = count?.status
+
+    if (!uuid || !status || !NON_TERMINAL_STATUSES.has(status)) {
+      if (stuckSinceRef.current && (!uuid || stuckSinceRef.current.uuid !== uuid)) {
+        stuckSinceRef.current = null
+      }
+      return
+    }
+
+    if (!stuckSinceRef.current || stuckSinceRef.current.uuid !== uuid) {
+      stuckSinceRef.current = { uuid, at: Date.now() }
+    }
+
+    let cancelled = false
+
+    const poll = async () => {
+      try {
+        const fresh = await services.cohortCreation.countCohort(undefined, undefined, undefined, uuid)
+        if (cancelled || !fresh) return
+
+        const freshStatus = fresh.status
+        if (freshStatus && !NON_TERMINAL_STATUSES.has(freshStatus)) {
+          dispatch(
+            updateCount({
+              status: freshStatus,
+              includePatient: fresh.includePatient,
+              jobFailMsg: fresh.jobFailMsg,
+              extra: fresh.extra,
+              snapshotId: fresh.snapshotId
+            })
+          )
+          return
+        }
+
+        const stuckSince = stuckSinceRef.current
+        if (stuckSince && stuckSince.uuid === uuid && Date.now() - stuckSince.at >= STUCK_TIMEOUT_MS) {
+          dispatch(
+            updateCount({
+              status: 'error',
+              jobFailMsg: `Aucune réponse du moteur de calcul après ${STUCK_TIMEOUT_MS / 60_000} min.`
+            })
+          )
+        }
+      } catch {
+        /* */
+      }
+    }
+
+    const interval = setInterval(poll, POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [count?.uuid, count?.status, dispatch])
+}


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/issues/3298.

Le spinner du compteur du constructeur de requête est aujourd'hui piloté uniquement par le WS \`JOB_STATUS\` (\`ControlPanel.tsx\`). Si le WS est perdu, broadcasté à un autre owner que celui qui consulte la requête, ou si le Query Executor ne PATCHe jamais le DM en terminal, le spinner ne s'arrête jamais et la seule sortie utilisateur est la déconnexion auto.

## Changements réalisés
- Nouveau hook \`useCountReconciliation\` (\`src/components/CreationCohort/ControlPanel/\`) qui polle \`GET /cohort/dated-measures/<uuid>/\` toutes les 30 s tant que \`count.status\` est non-terminal.
- Au passage d'un statut terminal côté back, dispatch \`updateCount\` (mêmes données que le listener WS).
- Au-delà de 10 min sans transition, dispatch \`updateCount({ status: 'error', jobFailMsg: ... })\` → réutilise l'Alert d'erreur existante + bouton "Relancer la requête" déjà présent. Aucune UI ajoutée.
- Hook plugué dans \`ControlPanel.tsx\` (+2 lignes).

## Impacts
- API : 1 GET supplémentaire toutes les 30 s pendant un count actif. Endpoint léger.
- UI : strictement aucun changement visible tant que le WS marche normalement.
- État Redux : la transition d'erreur passe par \`updateCount\`, identique à la branche \`.rejected\` du thunk.

## Tests réalisés
- 6 tests Vitest (\`__tests__/useCountReconciliation.test.ts\`) : no-op si count vide ; no-op si terminal ; transition \`started → finished\` ; bail-out après timeout ; cleanup au changement d'uuid ; swallow erreur réseau.
- ESLint clean.

## Risques
- Seuil de 10 min : si un count SOLR légitime dépasse 10 min, l'utilisateur verra un faux positif "erreur". À aligner avec le seuil back (15 min) si on veut réduire le faux positif (au prix d'une attente plus longue).
- Si le polling lui-même échoue (\`apiBack\` HS), on swallow et on retentera au prochain tick, le hook n'expose pas l'erreur réseau.

PR sœur côté back : aphp/Cohort360-Back-end#536.