### PR TITLE
fix(export): disable export when maintenance is active

### DIFF
--- a/src/__tests__/mappers/exports.test.ts
+++ b/src/__tests__/mappers/exports.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mapExportListToTable } from 'mappers/exports'
+import { JobStatus } from 'types'
+import { ExportCallbacks, ExportList } from 'types/export'
+import { Action, CellType } from 'types/table'
+
+const callbacks: ExportCallbacks = {
+  onDownload: vi.fn(),
+  onRetry: vi.fn()
+}
+
+const recentDate = new Date().toISOString()
+
+const baseExport: ExportList = {
+  uuid: 'uuid-1',
+  cohort_id: '42',
+  cohort_name: 'Cohorte test',
+  created_at: recentDate,
+  modified_at: recentDate,
+  output_format: 'csv',
+  owner: 'owner',
+  patients_count: 10,
+  request_job_status: JobStatus.FINISHED,
+  target_datalab: null,
+  target_name: 'export-test'
+}
+
+const getActions = (exportItem: ExportList, maintenanceIsActive: boolean): Action[] => {
+  const table = mapExportListToTable([exportItem], callbacks, maintenanceIsActive)
+  const actionsCell = table.rows[0].find((cell) => cell.type === CellType.ACTIONS)
+  return actionsCell?.value as Action[]
+}
+
+describe('mapExportListToTable - maintenance handling', () => {
+  describe('when maintenance is active (true)', () => {
+    it('should disable the download button', () => {
+      const [download] = getActions(baseExport, true)
+      expect(download.disabled).toBe(true)
+    })
+
+    it('should disable the retry button', () => {
+      const failedExport = { ...baseExport, request_job_status: JobStatus.FAILED }
+      const [, retry] = getActions(failedExport, true)
+      expect(retry.disabled).toBe(true)
+    })
+  })
+
+  describe('when maintenance is inactive (false)', () => {
+    it('should not disable the download button for a finished recent export', () => {
+      const [download] = getActions(baseExport, false)
+      expect(download.disabled).toBe(false)
+    })
+
+    it('should not disable the retry button for a failed export', () => {
+      const failedExport = { ...baseExport, request_job_status: JobStatus.FAILED }
+      const [, retry] = getActions(failedExport, false)
+      expect(retry.disabled).toBe(false)
+    })
+  })
+})

--- a/src/mappers/exports.ts
+++ b/src/mappers/exports.ts
@@ -8,7 +8,7 @@ import { JobStatus } from 'types'
 import { Refresh } from '@mui/icons-material'
 import { isDateBefore } from 'utils/dates'
 
-const mapExportsToRows = (list: ExportList[], callbacks: ExportCallbacks) => {
+const mapExportsToRows = (list: ExportList[], callbacks: ExportCallbacks, maintenanceIsActive: boolean) => {
   const rows: Row[] = []
   const unknown = 'N/A'
   const { onDownload, onRetry } = callbacks
@@ -19,13 +19,16 @@ const mapExportsToRows = (list: ExportList[], callbacks: ExportCallbacks) => {
         icon: Download,
         onClick: () => onDownload(elem.uuid, elem.target_name ?? elem.uuid, elem.output_format ?? ''),
         disabled:
-          elem.request_job_status !== JobStatus.FINISHED || (elem.created_at && isDateBefore(elem.created_at, 7))
+          maintenanceIsActive ||
+          elem.request_job_status !== JobStatus.FINISHED ||
+          (elem.created_at && isDateBefore(elem.created_at, 7))
       },
       {
         title: 'Relancer l’export',
         icon: Refresh,
         onClick: () => onRetry(elem.uuid),
         disabled:
+          maintenanceIsActive ||
           elem.request_job_status === JobStatus.NEW ||
           elem.request_job_status === JobStatus.ACCEPTED ||
           elem.request_job_status === JobStatus.LONG_PENDING ||
@@ -90,9 +93,13 @@ const mapExportsToColumns = (): Column[] => {
   ]
 }
 
-export const mapExportListToTable = (exportList: ExportList[], callbacks: ExportCallbacks) => {
+export const mapExportListToTable = (
+  exportList: ExportList[],
+  callbacks: ExportCallbacks,
+  maintenanceIsActive: boolean
+) => {
   const table: Table = { rows: [], columns: [] }
   table.columns = mapExportsToColumns()
-  table.rows = mapExportsToRows(exportList, callbacks)
+  table.rows = mapExportsToRows(exportList, callbacks, maintenanceIsActive)
   return table
 }

--- a/src/pages/Export/index.tsx
+++ b/src/pages/Export/index.tsx
@@ -141,14 +141,18 @@ const Export = () => {
 
   const table = useMemo(
     () =>
-      mapExportListToTable(exportList?.results ?? [], {
-        onDownload: (id) => {
-          void onDownload(id)
+      mapExportListToTable(
+        exportList?.results ?? [],
+        {
+          onDownload: (id) => {
+            void onDownload(id)
+          },
+          onRetry: (id) => {
+            void onRetry(id)
+          }
         },
-        onRetry: (id) => {
-          void onRetry(id)
-        }
-      }),
+        maintenanceIsActive
+      ),
     [exportList]
   )
 

--- a/src/pages/Export/index.tsx
+++ b/src/pages/Export/index.tsx
@@ -153,7 +153,7 @@ const Export = () => {
         },
         maintenanceIsActive
       ),
-    [exportList]
+    [exportList, maintenanceIsActive]
   )
 
   return (


### PR DESCRIPTION
## Objectif

fix: https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3325

Sur la page des exports, les boutons de téléchargement et de retry doivent être déasactivés pendant une maintenance de Cohort360

## Changements réalisés

Utilisation du booléen "maintenanceIsActive" lors de la création des 2 boutons

## Impacts
Front 

## Tests réalisés
manuels

## Risques
Aucun risques
