### PR TITLE
feat(homePage): add popup MEP

### DIFF
--- a/src/components/Welcome/MaintenancePopup/MaintenancePopup.tsx
+++ b/src/components/Welcome/MaintenancePopup/MaintenancePopup.tsx
@@ -13,7 +13,7 @@ const MaintenancePopup = ({ open, onClose }: MaintenancePopupProps) => {
   return (
     <Modal open={open} title="Maintenance" color="warning" readonly cancelText="Fermer" onClose={onClose}>
       <Typography textAlign="center">
-        Bien que l'application paraisse opérationnelle, elle est toujours en maintenance. Merci de revenir plus tard.
+        L'application est en phase de test et n'est pas opérationnelle. Merci de vous reconnecter plus tard.
       </Typography>
     </Modal>
   )

--- a/src/components/Welcome/MaintenancePopup/MaintenancePopup.tsx
+++ b/src/components/Welcome/MaintenancePopup/MaintenancePopup.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { Typography } from '@mui/material'
+
+import Modal from 'components/ui/Modal'
+
+type MaintenancePopupProps = {
+  open: boolean
+  onClose: () => void
+}
+
+const MaintenancePopup = ({ open, onClose }: MaintenancePopupProps) => {
+  return (
+    <Modal open={open} title="Maintenance" color="warning" readonly cancelText="Fermer" onClose={onClose}>
+      <Typography textAlign="center">
+        Bien que l'application paraisse opérationnelle, elle est toujours en maintenance. Merci de revenir plus tard.
+      </Typography>
+    </Modal>
+  )
+}
+
+export default MaintenancePopup

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -155,6 +155,9 @@ export type AppConfig = {
     }
     feasibilityReport: FeatureConfig
     contact: FeatureConfig
+    maintenancePopup: FeatureConfig & {
+      exceptionAphCodes: string[]
+    }
   }
   core: {
     fhir: {
@@ -436,6 +439,10 @@ let config: AppConfig = {
     },
     contact: {
       enabled: false
+    },
+    maintenancePopup: {
+      enabled: false,
+      exceptionAphCodes: []
     }
   },
   system: {

--- a/src/views/Welcome/Welcome.tsx
+++ b/src/views/Welcome/Welcome.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import moment from 'moment'
 
@@ -12,6 +12,7 @@ import PageContainer from 'components/ui/PageContainer'
 import PatientsCard from 'components/Welcome/PatientsCard/PatientsCard'
 import SearchPatientCard from 'components/Welcome/SearchPatientCard/SearchPatientCard'
 import TutorialsCard from 'components/Welcome/TutorialsCard/TutorialsCard'
+import MaintenancePopup from 'components/Welcome/MaintenancePopup/MaintenancePopup'
 import PreviewCard from 'components/ui/Cards/PreviewCard'
 import RequestsList from 'components/Researches/RequestsList'
 
@@ -25,6 +26,7 @@ import { listStaticContents, WebContent } from 'services/aphp/callApi'
 import Markdown from 'react-markdown'
 import { getBannerMessageLevel, sortContent } from 'data/infoMessage'
 import { plural } from 'utils/string'
+import { AppConfig } from 'config'
 
 const Welcome = () => {
   const { classes } = useStyles()
@@ -33,6 +35,14 @@ const Welcome = () => {
   const practitioner = useAppSelector((state) => state.me)
   const meState = useAppSelector((state) => state.me)
   const [bannerMessages, setBannerMessages] = useState<WebContent[]>([])
+
+  const appConfig = useContext(AppConfig)
+  const maintenancePopupConfig = appConfig.features.maintenancePopup
+  const userAphCode = practitioner?.userName
+  const maintenancePopupIsActive =
+    maintenancePopupConfig.enabled && !!userAphCode && !maintenancePopupConfig.exceptionAphCodes.includes(userAphCode)
+  const [maintenancePopupOpen, setMaintenancePopupOpen] = useState(false)
+  const maintenancePopupInitialized = useRef(false)
 
   const accessExpirations: AccessExpiration[] = meState?.accessExpirations ?? []
   const maintenanceIsActive = meState?.maintenance?.active
@@ -52,8 +62,16 @@ const Welcome = () => {
     fetchBannerMessages()
   }, [])
 
+  useEffect(() => {
+    if (!maintenancePopupInitialized.current && userAphCode) {
+      maintenancePopupInitialized.current = true
+      setMaintenancePopupOpen(maintenancePopupIsActive)
+    }
+  }, [userAphCode, maintenancePopupIsActive])
+
   return practitioner ? (
     <PageContainer alignItems={'center'}>
+      <MaintenancePopup open={maintenancePopupOpen} onClose={() => setMaintenancePopupOpen(false)} />
       <HeaderLayout
         title={`Bienvenue ${
           practitioner.impersonation


### PR DESCRIPTION
## Objectif

fix: https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3329

Permettre d'afficher une popup de maintenance sur la page d'accueil, activable via un feature flag, tout en excluant certains utilisateurs via une liste de codes APH. Le besoin : informer les utilisateurs que l'application est encore en maintenance malgré une apparence opérationnelle, sauf pour une liste d'exceptions (utilisateurs des TNR).

## Changements réalisés

Config : ajout d'un nouveau feature flag features.maintenancePopup avec la forme { enabled: boolean, exceptionAphCodes: string[] }.

Composant popup : popup basée sur le composant réutilisable components/ui/Modal pour rester cohérente avec le style des autres popups de l'application. Titre "Maintenance", bouton "Fermer", message en dur.

Page d'accueil : lecture du flag et du code utilisateur + logique d'activation :

## Impacts
Front

## Tests réalisés

Manuel : validation des 3 cas fonctionnels (flag off ; flag on + code dans la liste ; flag on + code hors liste).

## Risques
Pas de points de vigilance.
