### PR TITLE
feat(exploration): fhir call optimmization #3237

### DIFF
--- a/src/__tests__/services/callApiSearchFilters.test.ts
+++ b/src/__tests__/services/callApiSearchFilters.test.ts
@@ -22,7 +22,11 @@ vi.mock('config', async (importOriginal) => {
     ...actual,
     getConfig: vi.fn(() => ({
       system: { fhirUrl: 'http://localhost/fhir' },
-      core: { fhir: { filterActive: false, facetsExtensions: false }, valueSets: {} },
+      core: {
+        fhir: { filterActive: false, facetsExtensions: false },
+        valueSets: {},
+        codeSystems: { docStatus: 'doc-status-cs' }
+      },
       features: {
         medication: {
           valueSets: {
@@ -41,6 +45,9 @@ vi.mock('config', async (importOriginal) => {
         observation: {
           useObservationValueRestriction: false,
           useObservationDefaultValidated: false
+        },
+        questionnaires: {
+          defaultFilterFormNames: []
         },
         imaging: {
           valueSets: {
@@ -61,11 +68,21 @@ vi.mock('services/apiFhir', () => ({
   getAuthorizationMethod: vi.fn()
 }))
 
-vi.mock('./serviceFhirConfig', () => ({
+vi.mock('services/aphp/serviceFhirConfig', () => ({
   hasSearchParam: vi.fn(() => true)
 }))
 
-import { fetchMedicationRequest, fetchMedicationAdministration, fetchImaging, fetchObservation } from 'services/aphp/callApi'
+import {
+  fetchMedicationRequest,
+  fetchMedicationAdministration,
+  fetchImaging,
+  fetchObservation,
+  fetchCondition,
+  fetchProcedure,
+  fetchClaim,
+  fetchForms,
+  fetchDocumentReference
+} from 'services/aphp/callApi'
 
 const getParams = (): string[] => fhirSearchMock.mock.calls[0][1] as string[]
 
@@ -139,5 +156,51 @@ describe('callApi _include parameter', () => {
     const params = getParams()
     const includeParams = params.filter((p) => p.startsWith('_include='))
     expect(includeParams).toHaveLength(2)
+  })
+
+  it('fetchCondition adds _include params when provided', async () => {
+    await fetchCondition({ _include: ['Encounter:encounter', 'Patient:subject'] })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+  })
+
+  it('fetchProcedure adds _include params when provided', async () => {
+    await fetchProcedure({ _include: ['Encounter:encounter', 'Patient:subject'] })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+  })
+
+  it('fetchClaim adds _include params when provided', async () => {
+    await fetchClaim({ _include: ['Encounter:encounter', 'Patient:patient'] })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:patient')}`)
+  })
+
+  it('fetchMedicationRequest adds _include params when provided', async () => {
+    await fetchMedicationRequest({
+      minDate: null,
+      maxDate: null,
+      _include: ['Encounter:encounter', 'Patient:subject']
+    })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+  })
+
+  it('fetchForms adds _include params when provided', async () => {
+    await fetchForms({ _include: ['Encounter:encounter', 'Patient:subject'] })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+  })
+
+  it('fetchDocumentReference adds _include params via the shared helper', async () => {
+    await fetchDocumentReference({ _include: ['Encounter:encounter', 'Patient:patient'] })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:patient')}`)
   })
 })

--- a/src/__tests__/services/callApiSearchFilters.test.ts
+++ b/src/__tests__/services/callApiSearchFilters.test.ts
@@ -38,6 +38,10 @@ vi.mock('config', async (importOriginal) => {
             }
           }
         },
+        observation: {
+          useObservationValueRestriction: false,
+          useObservationDefaultValidated: false
+        },
         imaging: {
           valueSets: {
             imagingModalities: { url: MODALITY_VS, codeSystemUrls: [MODALITY_CS], resourceType: 'CodeSystem' }
@@ -61,7 +65,7 @@ vi.mock('./serviceFhirConfig', () => ({
   hasSearchParam: vi.fn(() => true)
 }))
 
-import { fetchMedicationRequest, fetchMedicationAdministration, fetchImaging } from 'services/aphp/callApi'
+import { fetchMedicationRequest, fetchMedicationAdministration, fetchImaging, fetchObservation } from 'services/aphp/callApi'
 
 const getParams = (): string[] => fhirSearchMock.mock.calls[0][1] as string[]
 
@@ -89,5 +93,51 @@ describe('callApi search filters - CodeSystem vs ValueSet system url', () => {
     const params = getParams()
     expect(params).toContain(`modality=${encodeURIComponent(`${MODALITY_CS}|CT`)}`)
     expect(params.join('&')).not.toContain(encodeURIComponent(MODALITY_VS))
+  })
+})
+
+describe('callApi _include parameter', () => {
+  beforeEach(() => {
+    fhirSearchMock.mockClear()
+  })
+
+  it('fetchImaging adds encoded _include params when provided', async () => {
+    await fetchImaging({ _include: ['Encounter:encounter', 'Patient:patient'] })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:patient')}`)
+  })
+
+  it('fetchImaging does not add any _include param when omitted', async () => {
+    await fetchImaging({ modalities: ['CT'] })
+    const params = getParams()
+    expect(params.some((p) => p.startsWith('_include='))).toBe(false)
+  })
+
+  it('fetchObservation supports Patient:subject include', async () => {
+    await fetchObservation({ rowStatus: false, _include: ['Encounter:encounter', 'Patient:subject'] })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+  })
+
+  it('fetchMedicationAdministration supports Encounter:context include', async () => {
+    await fetchMedicationAdministration({
+      minDate: null,
+      maxDate: null,
+      _include: ['Encounter:context', 'Patient:subject']
+    })
+    const params = getParams()
+    expect(params).toContain(`_include=${encodeURIComponent('Encounter:context')}`)
+    expect(params).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+  })
+
+  it('deduplicates repeated _include values', async () => {
+    await fetchImaging({
+      _include: ['Encounter:encounter', 'Encounter:encounter', 'Patient:patient'] as never
+    })
+    const params = getParams()
+    const includeParams = params.filter((p) => p.startsWith('_include='))
+    expect(includeParams).toHaveLength(2)
   })
 })

--- a/src/__tests__/utilsFunction/exploration.test.ts
+++ b/src/__tests__/utilsFunction/exploration.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Condition, Encounter, Patient } from 'fhir/r4'
+import { Direction, Order, PMSIFilters } from 'types/searchCriterias'
+import { FetchOptions, FetchParams, Patient as PatientType } from 'types/exploration'
+
+vi.mock('services/aphp/serviceValueSets', () => ({
+  getCodeList: vi.fn()
+}))
+
+vi.mock('utils/fillElement', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('utils/fillElement')>()
+  return {
+    ...actual,
+    getResourceInfos: vi.fn(),
+    getResourceInfosFromBundle: vi.fn()
+  }
+})
+
+vi.mock('utils/encounter', () => ({
+  linkElementWithEncounter: vi.fn()
+}))
+
+import { fetcherWithParams } from 'utils/exploration'
+import { getResourceInfos, getResourceInfosFromBundle } from 'utils/fillElement'
+import { linkElementWithEncounter } from 'utils/encounter'
+
+const mockGetResourceInfos = vi.mocked(getResourceInfos)
+const mockGetResourceInfosFromBundle = vi.mocked(getResourceInfosFromBundle)
+const mockLinkElementWithEncounter = vi.mocked(linkElementWithEncounter)
+
+const makeCondition = (id: string): Condition => ({
+  resourceType: 'Condition',
+  id,
+  subject: { reference: 'Patient/p1' },
+  encounter: { reference: 'Encounter/e1' }
+})
+
+const makePatient = (id: string): Patient => ({ resourceType: 'Patient', id })
+const makeEncounter = (id: string): Encounter => ({
+  resourceType: 'Encounter',
+  id,
+  status: 'finished',
+  class: {}
+})
+
+const makeBundle = (resources: object[], total = resources.length) =>
+  ({
+    data: {
+      resourceType: 'Bundle',
+      total,
+      meta: {},
+      entry: resources.map((resource) => ({ resource }))
+    }
+  }) as never
+
+const baseParams: FetchParams &
+  FetchOptions<PMSIFilters> & {
+    deidentified: boolean
+    patient: PatientType | null
+    groupId?: string[]
+    isPatientData?: boolean
+  } = {
+  page: 1,
+  size: 20,
+  includeFacets: false,
+  orderBy: { orderBy: Order.DATE, orderDirection: Direction.DESC },
+  searchInput: '',
+  filters: {} as PMSIFilters,
+  groupId: ['g1'],
+  deidentified: false,
+  patient: null
+}
+
+describe('fetcherWithParams _include handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetResourceInfos.mockResolvedValue([])
+    mockGetResourceInfosFromBundle.mockResolvedValue([])
+    mockLinkElementWithEncounter.mockResolvedValue([])
+  })
+
+  it('uses included Patient/Encounter from the bundle (no extra fetch) when not in patient context', async () => {
+    const condition = makeCondition('c1')
+    const patient = makePatient('p1')
+    const encounter = makeEncounter('e1')
+    const list = makeBundle([condition, patient, encounter])
+
+    await fetcherWithParams(
+      () => Promise.resolve(list),
+      () => Promise.resolve(makeBundle([])),
+      { ...baseParams, deidentified: false, patient: null }
+    )
+
+    expect(mockGetResourceInfosFromBundle).toHaveBeenCalledTimes(1)
+    expect(mockGetResourceInfos).not.toHaveBeenCalled()
+
+    const [mainResources, deid, patients, encounters] = mockGetResourceInfosFromBundle.mock.calls[0]
+    expect(mainResources).toEqual([condition])
+    expect(deid).toBe(false)
+    expect(patients).toEqual([patient])
+    expect(encounters).toEqual([encounter])
+  })
+
+  it('falls back to getResourceInfos when the bundle has no included resources', async () => {
+    const condition = makeCondition('c1')
+    const list = makeBundle([condition])
+
+    await fetcherWithParams(
+      () => Promise.resolve(list),
+      () => Promise.resolve(makeBundle([])),
+      { ...baseParams, deidentified: false, patient: null }
+    )
+
+    expect(mockGetResourceInfos).toHaveBeenCalledTimes(1)
+    expect(mockGetResourceInfosFromBundle).not.toHaveBeenCalled()
+    expect(mockGetResourceInfos.mock.calls[0][0]).toEqual([condition])
+  })
+
+  it('uses getResourceInfosFromBundle in deidentified mode even without included patients', async () => {
+    const condition = makeCondition('c1')
+    const encounter = makeEncounter('e1')
+    const list = makeBundle([condition, encounter])
+
+    await fetcherWithParams(
+      () => Promise.resolve(list),
+      () => Promise.resolve(makeBundle([])),
+      { ...baseParams, deidentified: true, patient: null }
+    )
+
+    expect(mockGetResourceInfosFromBundle).toHaveBeenCalledTimes(1)
+    expect(mockGetResourceInfos).not.toHaveBeenCalled()
+    const [mainResources, deid, patients, encounters] = mockGetResourceInfosFromBundle.mock.calls[0]
+    expect(mainResources).toEqual([condition])
+    expect(deid).toBe(true)
+    expect(patients).toEqual([])
+    expect(encounters).toEqual([encounter])
+  })
+
+  it('uses linkElementWithEncounter in patient context and ignores included resources', async () => {
+    const condition = makeCondition('c1')
+    const patient = makePatient('p1')
+    const encounter = makeEncounter('e1')
+    const list = makeBundle([condition, patient, encounter])
+
+    await fetcherWithParams(
+      () => Promise.resolve(list),
+      () => Promise.resolve(makeBundle([])),
+      { ...baseParams, deidentified: false, patient: { infos: { hospits: [] } } as unknown as PatientType }
+    )
+
+    expect(mockLinkElementWithEncounter).toHaveBeenCalledTimes(1)
+    expect(mockGetResourceInfosFromBundle).not.toHaveBeenCalled()
+    expect(mockGetResourceInfos).not.toHaveBeenCalled()
+
+    expect(mockLinkElementWithEncounter.mock.calls[0][0]).toEqual([condition])
+  })
+
+  it('does not leak included Patient/Encounter into results.total', async () => {
+    const condition = makeCondition('c1')
+    const patient = makePatient('p1')
+    const encounter = makeEncounter('e1')
+
+    const list = makeBundle([condition, patient, encounter], 1)
+
+    const result = await fetcherWithParams(
+      () => Promise.resolve(list),
+      () => Promise.resolve(makeBundle([], 42)),
+      { ...baseParams, deidentified: false, patient: null }
+    )
+
+    expect(result.total).toBe(1)
+  })
+
+  it('returns the raw bundle for patient-data lists without enrichment', async () => {
+    const patient = makePatient('p1')
+    const list = makeBundle([patient])
+
+    const result = await fetcherWithParams(
+      () => Promise.resolve(list),
+      () => Promise.resolve(makeBundle([])),
+      { ...baseParams, deidentified: false, patient: null, isPatientData: true }
+    )
+
+    expect(mockGetResourceInfos).not.toHaveBeenCalled()
+    expect(mockGetResourceInfosFromBundle).not.toHaveBeenCalled()
+    expect(mockLinkElementWithEncounter).not.toHaveBeenCalled()
+    expect(result.list).toEqual([patient])
+  })
+})

--- a/src/__tests__/utilsFunction/fillElement.test.ts
+++ b/src/__tests__/utilsFunction/fillElement.test.ts
@@ -87,11 +87,13 @@ describe('test of getLinkedEncounter function', () => {
 })
 
 describe('test of isPatientResource function', () => {
+  const patient: Patient = { resourceType: 'Patient', id: '1' }
+  const encounter: Encounter = { resourceType: 'Encounter', id: '1', status: 'finished', class: {} }
   it('should return true for a Patient resource', () => {
-    expect(isPatientResource({ resourceType: 'Patient', id: '1' })).toBe(true)
+    expect(isPatientResource(patient)).toBe(true)
   })
   it('should return false for a non-Patient resource', () => {
-    expect(isPatientResource({ resourceType: 'Encounter', id: '1', status: 'finished', class: {} })).toBe(false)
+    expect(isPatientResource(encounter)).toBe(false)
   })
   it('should return false for undefined', () => {
     expect(isPatientResource(undefined)).toBe(false)
@@ -99,11 +101,13 @@ describe('test of isPatientResource function', () => {
 })
 
 describe('test of isEncounterResource function', () => {
+  const patient: Patient = { resourceType: 'Patient', id: '1' }
+  const encounter: Encounter = { resourceType: 'Encounter', id: '1', status: 'finished', class: {} }
   it('should return true for an Encounter resource', () => {
-    expect(isEncounterResource({ resourceType: 'Encounter', id: '1', status: 'finished', class: {} })).toBe(true)
+    expect(isEncounterResource(encounter)).toBe(true)
   })
   it('should return false for a non-Encounter resource', () => {
-    expect(isEncounterResource({ resourceType: 'Patient', id: '1' })).toBe(false)
+    expect(isEncounterResource(patient)).toBe(false)
   })
   it('should return false for undefined', () => {
     expect(isEncounterResource(undefined)).toBe(false)

--- a/src/__tests__/utilsFunction/fillElement.test.ts
+++ b/src/__tests__/utilsFunction/fillElement.test.ts
@@ -1,11 +1,12 @@
 import { form } from '__tests__/data/explorationData/questionnaires'
-import { Bundle, Encounter, Patient } from 'fhir/r4'
+import { Bundle, Condition, Encounter, Patient } from 'fhir/r4'
 import {
   getBundleResources,
   getEncounterIdPath,
   getLinkedEncounter,
   getLinkedPatient,
   getPatientIdPath,
+  getResourceInfosFromBundle,
   isEncounterResource,
   isPatientResource,
   retrieveEncounterIds,
@@ -146,5 +147,42 @@ describe('test of getBundleResources function', () => {
     const resources = getBundleResources(response)
     expect(resources).toHaveLength(1)
     expect(resources[0]).toBe(patient)
+  })
+})
+
+describe('test of getResourceInfosFromBundle function (deidentified)', () => {
+  const makeCondition = (id: string, patientId: string, encounterId: string): Condition => ({
+    resourceType: 'Condition',
+    id,
+    subject: { reference: `Patient/${patientId}` },
+    encounter: { reference: `Encounter/${encounterId}` }
+  })
+
+  it('enriches entries from the included Patient/Encounter without extra fetch', async () => {
+    const condition = makeCondition('c1', 'p1', 'e1')
+    const encounter: Encounter = {
+      resourceType: 'Encounter',
+      id: 'e1',
+      status: 'finished',
+      class: {},
+      serviceProvider: { display: 'UF Test' }
+    }
+
+    const result = await getResourceInfosFromBundle([condition], true, [], [encounter])
+
+    expect(result).toHaveLength(1)
+    const enriched = result[0] as unknown as { idPatient: string; NDA: string; serviceProvider: string }
+    expect(enriched.idPatient).toBe('p1')
+    expect(enriched.NDA).toBe('e1')
+    expect(enriched.serviceProvider).toBe('UF Test')
+  })
+
+  it('defaults serviceProvider when no matching encounter is included', async () => {
+    const condition = makeCondition('c1', 'p1', 'e1')
+
+    const result = await getResourceInfosFromBundle([condition], true, [], [])
+
+    const enriched = result[0] as unknown as { serviceProvider: string }
+    expect(enriched.serviceProvider).toBe('Non renseigné')
   })
 })

--- a/src/__tests__/utilsFunction/fillElement.test.ts
+++ b/src/__tests__/utilsFunction/fillElement.test.ts
@@ -1,10 +1,13 @@
 import { form } from '__tests__/data/explorationData/questionnaires'
-import { Encounter, Patient } from 'fhir/r4'
+import { Bundle, Encounter, Patient } from 'fhir/r4'
 import {
+  getBundleResources,
   getEncounterIdPath,
   getLinkedEncounter,
   getLinkedPatient,
   getPatientIdPath,
+  isEncounterResource,
+  isPatientResource,
   retrieveEncounterIds,
   retrievePatientIds
 } from 'utils/fillElement'
@@ -80,5 +83,64 @@ describe('test of getLinkedEncounter function', () => {
   })
   it("should return undefined if no encounter id matches the entry's", () => {
     expect(getLinkedEncounter([], _form)).toBeUndefined()
+  })
+})
+
+describe('test of isPatientResource function', () => {
+  it('should return true for a Patient resource', () => {
+    expect(isPatientResource({ resourceType: 'Patient', id: '1' })).toBe(true)
+  })
+  it('should return false for a non-Patient resource', () => {
+    expect(isPatientResource({ resourceType: 'Encounter', id: '1', status: 'finished', class: {} })).toBe(false)
+  })
+  it('should return false for undefined', () => {
+    expect(isPatientResource(undefined)).toBe(false)
+  })
+})
+
+describe('test of isEncounterResource function', () => {
+  it('should return true for an Encounter resource', () => {
+    expect(isEncounterResource({ resourceType: 'Encounter', id: '1', status: 'finished', class: {} })).toBe(true)
+  })
+  it('should return false for a non-Encounter resource', () => {
+    expect(isEncounterResource({ resourceType: 'Patient', id: '1' })).toBe(false)
+  })
+  it('should return false for undefined', () => {
+    expect(isEncounterResource(undefined)).toBe(false)
+  })
+})
+
+describe('test of getBundleResources function', () => {
+  const makeBundleResponse = (bundle: Partial<Bundle>) => ({ data: bundle as never })
+
+  it('should return an empty array when data is not a Bundle', () => {
+    expect(getBundleResources({ data: { resourceType: 'OperationOutcome' } as never })).toEqual([])
+  })
+
+  it('should return an empty array when the Bundle has no entry', () => {
+    expect(getBundleResources(makeBundleResponse({ resourceType: 'Bundle' }))).toEqual([])
+  })
+
+  it('should extract the resources from the Bundle entries', () => {
+    const patient: Patient = { resourceType: 'Patient', id: 'p1' }
+    const encounter: Encounter = { resourceType: 'Encounter', id: 'e1', status: 'finished', class: {} }
+    const response = makeBundleResponse({
+      resourceType: 'Bundle',
+      entry: [{ resource: patient }, { resource: encounter }]
+    })
+    const resources = getBundleResources(response)
+    expect(resources).toHaveLength(2)
+    expect(resources).toEqual([patient, encounter])
+  })
+
+  it('should filter out entries without a resource', () => {
+    const patient: Patient = { resourceType: 'Patient', id: 'p1' }
+    const response = makeBundleResponse({
+      resourceType: 'Bundle',
+      entry: [{ resource: patient }, {}]
+    })
+    const resources = getBundleResources(response)
+    expect(resources).toHaveLength(1)
+    expect(resources[0]).toBe(patient)
   })
 })

--- a/src/components/ExplorationBoard/config/biology.ts
+++ b/src/components/ExplorationBoard/config/biology.ts
@@ -185,6 +185,7 @@ const fetchList = (
     code: code.map((code) => encodeURI(`${code.system}|${code.id}`)).join(','),
     rowStatus: validatedStatus,
     subject: patient?.id,
+    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
     ...getCommonParamsList(fetchParams, groupId),
     signal
   }

--- a/src/components/ExplorationBoard/config/biology.ts
+++ b/src/components/ExplorationBoard/config/biology.ts
@@ -185,7 +185,7 @@ const fetchList = (
     code: code.map((code) => encodeURI(`${code.system}|${code.id}`)).join(','),
     rowStatus: validatedStatus,
     subject: patient?.id,
-    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
+    _include: ['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[],
     ...getCommonParamsList(fetchParams, groupId),
     signal
   }

--- a/src/components/ExplorationBoard/config/documents.ts
+++ b/src/components/ExplorationBoard/config/documents.ts
@@ -100,7 +100,7 @@ const fetchList = (
   }
   const paramsWithInclude = {
     ...params,
-    _include: ['Encounter:encounter', 'Patient:patient'] as ('Encounter:encounter' | 'Patient:patient')[]
+    _include: ['Encounter:encounter', 'Patient:patient'] satisfies ('Encounter:encounter' | 'Patient:patient')[]
   }
   const paramsFetchAll = {
     patient: patient?.id,

--- a/src/components/ExplorationBoard/config/documents.ts
+++ b/src/components/ExplorationBoard/config/documents.ts
@@ -26,7 +26,7 @@ import { Table, Row, CellType, Column } from 'types/table'
 import { getDocumentStatus } from 'utils/documentsFormatter'
 import CheckIcon from 'assets/icones/check.svg?react'
 import CancelIcon from 'assets/icones/times.svg?react'
-import { DocumentReference, Encounter, Patient as FhirPatient, Resource } from 'fhir/r4'
+import { DocumentReference, Resource } from 'fhir/r4'
 import { fetchDocumentReference } from 'services/aphp/callApi'
 import { ResourceType } from 'types/requestCriterias'
 import { getConfig } from 'config'
@@ -40,7 +40,13 @@ import {
 import { FhirItem } from 'types/valueSet'
 import { Buffer } from 'buffer'
 import { SourceType } from 'types/scope'
-import { getResourceInfos, getResourceInfosFromBundle } from 'utils/fillElement'
+import {
+  getBundleResources,
+  getResourceInfos,
+  getResourceInfosFromBundle,
+  isEncounterResource,
+  isPatientResource
+} from 'utils/fillElement'
 import { getExtension } from 'utils/fhir'
 import { linkElementWithEncounter } from 'utils/encounter'
 import { getDocTypeLabel } from '../../../utils/docTypesHelper'
@@ -123,24 +129,6 @@ const isDocumentReference = (resource: Resource | undefined): resource is Docume
   return resource?.resourceType === 'DocumentReference'
 }
 
-const isEncounter = (resource: Resource | undefined): resource is Encounter => {
-  return resource?.resourceType === 'Encounter'
-}
-
-const isPatientResource = (resource: Resource | undefined): resource is FhirPatient => {
-  return resource?.resourceType === 'Patient'
-}
-
-const getBundleResources = (response: { data: FHIR_Bundle_Response<DocumentReference> }): Resource[] => {
-  if (response.data.resourceType !== 'Bundle') return []
-
-  return (
-    response.data.entry
-      ?.map((entry) => entry.resource as unknown as Resource | undefined)
-      .filter((resource): resource is Resource => !!resource) ?? []
-  )
-}
-
 const fetchDocumentsList = async (
   paramsWithInclude: Parameters<typeof fetchDocumentReference>[0],
   paramsFetchAll: Parameters<typeof fetchDocumentReference>[0] | null,
@@ -157,7 +145,7 @@ const fetchDocumentsList = async (
   const resources = getBundleResources(list)
   const documents = resources.filter(isDocumentReference)
   const includedPatients = resources.filter(isPatientResource)
-  const includedEncounters = resources.filter(isEncounter)
+  const includedEncounters = resources.filter(isEncounterResource)
 
   let listResources
   if (patient) {

--- a/src/components/ExplorationBoard/config/forms.ts
+++ b/src/components/ExplorationBoard/config/forms.ts
@@ -135,7 +135,7 @@ const fetchList = async (
     formName: formName.join(','),
     uniqueFacet: ['subject'],
     patient: patient?.id,
-    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
+    _include: ['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[],
     ...getCommonParamsList(fetchParams, groupId),
     signal
   }

--- a/src/components/ExplorationBoard/config/forms.ts
+++ b/src/components/ExplorationBoard/config/forms.ts
@@ -135,6 +135,7 @@ const fetchList = async (
     formName: formName.join(','),
     uniqueFacet: ['subject'],
     patient: patient?.id,
+    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
     ...getCommonParamsList(fetchParams, groupId),
     signal
   }

--- a/src/components/ExplorationBoard/config/imaging.ts
+++ b/src/components/ExplorationBoard/config/imaging.ts
@@ -260,7 +260,7 @@ const fetchList = (
     encounterStatus: encounterStatus.map(({ id }) => id),
     uniqueFacet: ['subject'],
     patient: patient?.id,
-    _include: ['Encounter:encounter', 'Patient:patient'] as ('Encounter:encounter' | 'Patient:patient')[],
+    _include: ['Encounter:encounter', 'Patient:patient'] satisfies ('Encounter:encounter' | 'Patient:patient')[],
     ...getCommonParamsList(fetchParams, groupId),
     signal
   }

--- a/src/components/ExplorationBoard/config/imaging.ts
+++ b/src/components/ExplorationBoard/config/imaging.ts
@@ -260,6 +260,7 @@ const fetchList = (
     encounterStatus: encounterStatus.map(({ id }) => id),
     uniqueFacet: ['subject'],
     patient: patient?.id,
+    _include: ['Encounter:encounter', 'Patient:patient'] as ('Encounter:encounter' | 'Patient:patient')[],
     ...getCommonParamsList(fetchParams, groupId),
     signal
   }

--- a/src/components/ExplorationBoard/config/medication.ts
+++ b/src/components/ExplorationBoard/config/medication.ts
@@ -225,7 +225,7 @@ const fetchAdministrationList = (
   const { administrationRoutes } = filters
   const params = {
     route: administrationRoutes?.map((type) => type.id),
-    _include: ['Encounter:context', 'Patient:subject'] as ('Encounter:context' | 'Patient:subject')[],
+    _include: ['Encounter:context', 'Patient:subject'] satisfies ('Encounter:context' | 'Patient:subject')[],
     ...getMedicationFilters(filters, fetchParams, patient, groupId),
     signal
   }
@@ -255,7 +255,7 @@ const fetchRequestList = (
   const { prescriptionTypes } = filters
   const params = {
     type: prescriptionTypes?.map((type) => type.id),
-    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
+    _include: ['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[],
     ...getMedicationFilters(filters, fetchParams, patient, groupId),
     signal
   }

--- a/src/components/ExplorationBoard/config/medication.ts
+++ b/src/components/ExplorationBoard/config/medication.ts
@@ -225,6 +225,7 @@ const fetchAdministrationList = (
   const { administrationRoutes } = filters
   const params = {
     route: administrationRoutes?.map((type) => type.id),
+    _include: ['Encounter:context', 'Patient:subject'] as ('Encounter:context' | 'Patient:subject')[],
     ...getMedicationFilters(filters, fetchParams, patient, groupId),
     signal
   }
@@ -254,6 +255,7 @@ const fetchRequestList = (
   const { prescriptionTypes } = filters
   const params = {
     type: prescriptionTypes?.map((type) => type.id),
+    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
     ...getMedicationFilters(filters, fetchParams, patient, groupId),
     signal
   }

--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -161,6 +161,14 @@ const addFacetParams = (options: string[], facet?: string[], uniqueFacet?: strin
   return result
 }
 
+const addIncludeParams = (options: string[], _include?: string[]): string[] => {
+  const includes = uniqueValues(_include)
+  if (includes.length > 0) {
+    return [...options, ...includes.map((include) => `_include=${encodeURIComponent(include)}`)]
+  }
+  return options
+}
+
 /**
  * Patient Resource
  *
@@ -374,7 +382,6 @@ export const fetchDocumentReference = async (
   const encounterIdentifier = args['encounter-identifier']
   const patientIdentifier = args['patient-identifier']
   const appConfig = getConfig()
-  const includes = uniqueValues(_include)
 
   _list = uniqueValues(_list)
   facet = uniqueValues(facet)
@@ -433,8 +440,7 @@ export const fetchDocumentReference = async (
   if (appConfig.core.fhir.facetsExtensions && uniqueFacet && uniqueFacet.length > 0)
     options = [...options, `unique-facet=${reduceParamValues(uniqueFacet)}`]
   if (_elements && _elements.length > 0) options = [...options, `_elements=${reduceParamValues(_elements)}`]
-  if (includes.length > 0)
-    options = [...options, ...includes.map((include) => `_include=${encodeURIComponent(include)}`)]
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<DocumentReference>>('DocumentReference', options, {
     signal: signal
@@ -567,6 +573,7 @@ type fetchProcedureProps = {
   executiveUnits?: string[]
   encounterStatus?: string[]
   uniqueFacet?: string[]
+  _include?: ('Encounter:encounter' | 'Patient:subject')[]
 }
 export const fetchProcedure = async (args: fetchProcedureProps): FHIR_Bundle_Promise_Response<Procedure> => {
   const {
@@ -582,7 +589,8 @@ export const fetchProcedure = async (args: fetchProcedureProps): FHIR_Bundle_Pro
     minDate,
     maxDate,
     executiveUnits,
-    encounterStatus
+    encounterStatus,
+    _include
   } = args
   const docStatusCodeSystem = getConfig().core.codeSystems.docStatus
   let { _list, uniqueFacet } = args
@@ -618,6 +626,7 @@ export const fetchProcedure = async (args: fetchProcedureProps): FHIR_Bundle_Pro
   if (encounterStatus && encounterStatus.length > 0)
     options = [...options, `${ProcedureParamsKeys.ENCOUNTER_STATUS}=${encounterStatus}`]
   options = addFacetParams(options, undefined, uniqueFacet)
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<Procedure>>('Procedure', options, {
     signal: args.signal
@@ -647,6 +656,7 @@ type fetchClaimProps = {
   executiveUnits?: string[]
   encounterStatus?: string[]
   uniqueFacet?: string[]
+  _include?: ('Encounter:encounter' | 'Patient:patient')[]
 }
 export const fetchClaim = async (args: fetchClaimProps): FHIR_Bundle_Promise_Response<Claim> => {
   const {
@@ -660,7 +670,8 @@ export const fetchClaim = async (args: fetchClaimProps): FHIR_Bundle_Promise_Res
     minCreated,
     maxCreated,
     executiveUnits,
-    encounterStatus
+    encounterStatus,
+    _include
   } = args
   const sortPrefix = getSortPrefix(sortDirection)
   let { _list, uniqueFacet } = args
@@ -692,6 +703,7 @@ export const fetchClaim = async (args: fetchClaimProps): FHIR_Bundle_Promise_Res
     options = [...options, `unique-facet=${reduceParamValues(uniqueFacet)}`]
 
   if (!patient && _list && _list.length > 0) options = [...options, `_list=${reduceParamValues(_list)}`]
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<Claim>>('Claim', options, {
     signal: args.signal
@@ -724,10 +736,23 @@ type fetchConditionProps = {
   executiveUnits?: string[]
   encounterStatus?: string[]
   uniqueFacet?: string[]
+  _include?: ('Encounter:encounter' | 'Patient:subject')[]
 }
 // eslint-disable-next-line max-statements
 export const fetchCondition = async (args: fetchConditionProps): FHIR_Bundle_Promise_Response<Condition> => {
-  const { size, offset, _sort, sortDirection, subject, code, source, _text, executiveUnits, encounterStatus } = args
+  const {
+    size,
+    offset,
+    _sort,
+    sortDirection,
+    subject,
+    code,
+    source,
+    _text,
+    executiveUnits,
+    encounterStatus,
+    _include
+  } = args
   const sortPrefix = getSortPrefix(sortDirection)
   let { _list, type, uniqueFacet } = args
   const encounterIdentifier = args['encounter-identifier']
@@ -765,6 +790,7 @@ export const fetchCondition = async (args: fetchConditionProps): FHIR_Bundle_Pro
     const urlString = type.map((id) => id).join(',')
     options = [...options, `${ConditionParamsKeys.DIAGNOSTIC_TYPES}=${encodeURIComponent(urlString)}`]
   }
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<Condition>>('Condition', options, {
     signal: args.signal
@@ -792,6 +818,7 @@ type fetchObservationProps = {
   encounterStatus?: string[]
   uniqueFacet?: 'subject'[]
   'patient-identifier'?: string
+  _include?: ('Encounter:encounter' | 'Patient:patient' | 'Patient:subject')[]
 }
 export const fetchObservation = async (args: fetchObservationProps): FHIR_Bundle_Promise_Response<Observation> => {
   const {
@@ -809,7 +836,8 @@ export const fetchObservation = async (args: fetchObservationProps): FHIR_Bundle
     rowStatus,
     signal,
     executiveUnits,
-    encounterStatus
+    encounterStatus,
+    _include
   } = args
   let { _list, uniqueFacet } = args
   const patientIdentifier = args['patient-identifier']
@@ -843,6 +871,7 @@ export const fetchObservation = async (args: fetchObservationProps): FHIR_Bundle
   if (patientIdentifier) options = [...options, `${ObservationParamsKeys.IPP}=${patientIdentifier}`]
   options = addFacetParams(options, undefined, uniqueFacet)
   options = addListParams(options, _list, !subject)
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<Observation>>('Observation', options, {
     signal: signal
@@ -871,6 +900,7 @@ type fetchMedicationRequestProps = {
   executiveUnits?: string[]
   encounterStatus?: string[]
   uniqueFacet?: string[]
+  _include?: ('Encounter:encounter' | 'Patient:subject')[]
 }
 export const fetchMedicationRequest = async (
   args: fetchMedicationRequestProps
@@ -891,7 +921,8 @@ export const fetchMedicationRequest = async (
     maxDate,
     signal,
     executiveUnits,
-    encounterStatus
+    encounterStatus,
+    _include
   } = args
   let { _list, uniqueFacet } = args
 
@@ -924,6 +955,7 @@ export const fetchMedicationRequest = async (
     options = [...options, `${PrescriptionParamsKeys.ENCOUNTER_STATUS}=${encounterStatus}`]
   options = addFacetParams(options, undefined, uniqueFacet)
   options = addListParams(options, _list, !subject)
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<MedicationRequest>>('MedicationRequest', options, {
     signal: signal
@@ -951,6 +983,7 @@ type fetchMedicationAdministrationProps = {
   executiveUnits?: string[]
   encounterStatus?: string[]
   uniqueFacet?: string[]
+  _include?: ('Encounter:context' | 'Patient:subject')[]
 }
 export const fetchMedicationAdministration = async (
   args: fetchMedicationAdministrationProps
@@ -971,7 +1004,8 @@ export const fetchMedicationAdministration = async (
     maxDate,
     signal,
     executiveUnits,
-    encounterStatus
+    encounterStatus,
+    _include
   } = args
   let { _list, uniqueFacet } = args
 
@@ -1004,6 +1038,7 @@ export const fetchMedicationAdministration = async (
     options = [...options, `${AdministrationParamsKeys.ENCOUNTER_STATUS}=${encounterStatus}`]
   options = addFacetParams(options, undefined, uniqueFacet)
   options = addListParams(options, _list, !subject)
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<MedicationAdministration>>(
     'MedicationAdministration',
@@ -1034,6 +1069,7 @@ type fetchImagingProps = {
   executiveUnits?: string[]
   encounterStatus?: string[]
   uniqueFacet?: string[]
+  _include?: ('Encounter:encounter' | 'Patient:patient')[]
 }
 export const fetchImaging = async (args: fetchImagingProps): FHIR_Bundle_Promise_Response<ImagingStudy> => {
   const {
@@ -1051,7 +1087,8 @@ export const fetchImaging = async (args: fetchImagingProps): FHIR_Bundle_Promise
     signal,
     modalities,
     executiveUnits,
-    encounterStatus
+    encounterStatus,
+    _include
   } = args
   let { _list, uniqueFacet } = args
 
@@ -1083,6 +1120,7 @@ export const fetchImaging = async (args: fetchImagingProps): FHIR_Bundle_Promise
     options = [...options, `${ImagingParamsKeys.ENCOUNTER_STATUS}=${encounterStatus}`]
   options = addListParams(options, _list)
   options = addFacetParams(options, undefined, uniqueFacet)
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<ImagingStudy>>('ImagingStudy', options, {
     signal: signal
@@ -1106,6 +1144,7 @@ type fetchFormsProps = {
   ipp?: string
   signal?: AbortSignal
   uniqueFacet?: string[]
+  _include?: ('Encounter:encounter' | 'Patient:subject')[]
 }
 export const fetchForms = async (args: fetchFormsProps) => {
   const {
@@ -1121,7 +1160,8 @@ export const fetchForms = async (args: fetchFormsProps) => {
     _sort,
     sortDirection,
     ipp,
-    signal
+    signal,
+    _include
   } = args
   let { uniqueFacet } = args
   uniqueFacet = uniqueValues(uniqueFacet)
@@ -1145,6 +1185,7 @@ export const fetchForms = async (args: fetchFormsProps) => {
     options = [...options, `${QuestionnaireResponseParamsKeys.ENCOUNTER_STATUS}=${encounterStatus}`]
   if (ipp) options = [...options, `${QuestionnaireResponseParamsKeys.IPP}=${ipp}`]
   options = addFacetParams(options, undefined, uniqueFacet)
+  options = addIncludeParams(options, _include)
 
   const response = await fhirSearch<FHIR_Bundle_Response<QuestionnaireResponse>>('QuestionnaireResponse', options, {
     signal: signal

--- a/src/services/aphp/servicePmsi.ts
+++ b/src/services/aphp/servicePmsi.ts
@@ -35,6 +35,7 @@ export const fetchConditionList = (
     'max-recorded-date': durationRange?.[1] ?? '',
     uniqueFacet: ['subject'],
     subject: patient?.infos?.id,
+    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.CODE : Order.ONSET_DATE,
     signal
@@ -68,6 +69,7 @@ export const fetchProcedureList = (
     maxDate: durationRange?.[1] ?? '',
     uniqueFacet: ['subject'],
     subject: patient?.id,
+    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.CODE : Order.DATE,
     signal
@@ -100,6 +102,7 @@ export const fetchClaimList = (
     maxCreated: durationRange?.[1] ?? '',
     uniqueFacet: ['patient'],
     patient: patient?.id,
+    _include: ['Encounter:encounter', 'Patient:patient'] as ('Encounter:encounter' | 'Patient:patient')[],
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.DIAGNOSIS : Order.CREATED,
     signal

--- a/src/services/aphp/servicePmsi.ts
+++ b/src/services/aphp/servicePmsi.ts
@@ -35,7 +35,7 @@ export const fetchConditionList = (
     'max-recorded-date': durationRange?.[1] ?? '',
     uniqueFacet: ['subject'],
     subject: patient?.infos?.id,
-    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
+    _include: ['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[],
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.CODE : Order.ONSET_DATE,
     signal
@@ -69,7 +69,7 @@ export const fetchProcedureList = (
     maxDate: durationRange?.[1] ?? '',
     uniqueFacet: ['subject'],
     subject: patient?.id,
-    _include: ['Encounter:encounter', 'Patient:subject'] as ('Encounter:encounter' | 'Patient:subject')[],
+    _include: ['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[],
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.CODE : Order.DATE,
     signal
@@ -102,7 +102,7 @@ export const fetchClaimList = (
     maxCreated: durationRange?.[1] ?? '',
     uniqueFacet: ['patient'],
     patient: patient?.id,
-    _include: ['Encounter:encounter', 'Patient:patient'] as ('Encounter:encounter' | 'Patient:patient')[],
+    _include: ['Encounter:encounter', 'Patient:patient'] satisfies ('Encounter:encounter' | 'Patient:patient')[],
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.DIAGNOSIS : Order.CREATED,
     signal

--- a/src/utils/exploration.ts
+++ b/src/utils/exploration.ts
@@ -17,7 +17,13 @@ import { FHIR_Bundle_Promise_Response, FHIR_API_Response } from 'types'
 import { ExplorationResults, FetchOptions, FetchParams, Patient as PatientType } from 'types/exploration'
 import { getCodeList } from 'services/aphp/serviceValueSets'
 import { getApiResponseResources } from './apiHelpers'
-import { getResourceInfos } from './fillElement'
+import {
+  getBundleResources,
+  getResourceInfos,
+  getResourceInfosFromBundle,
+  isEncounterResource,
+  isPatientResource
+} from './fillElement'
 import { atLeastOneSearchCriteria } from './filters'
 import { AxiosResponse } from 'axios'
 import { getExtension } from './fhir'
@@ -132,11 +138,28 @@ export const fetcherWithParams = async <T extends Patient | NonPatientResource, 
   if (isPatientData) {
     results.list = bundle
   } else {
-    results.list = (
-      patient
-        ? await linkElementWithEncounter(bundle as NonPatientResource[], patient?.infos.hospits, deidentified)
-        : await getResourceInfos(bundle as NonPatientResource[], deidentified, groupId?.[0])
-    ) as T[]
+    const includedResources = getBundleResources(list)
+    const includedPatients = includedResources.filter(isPatientResource)
+    const includedEncounters = includedResources.filter(isEncounterResource)
+
+    const mainResources = (
+      includedPatients.length > 0 || includedEncounters.length > 0
+        ? bundle.filter((resource) => !isPatientResource(resource) && !isEncounterResource(resource))
+        : bundle
+    ) as NonPatientResource[]
+
+    if (patient) {
+      results.list = (await linkElementWithEncounter(mainResources, patient?.infos.hospits, deidentified)) as T[]
+    } else if (includedEncounters.length > 0 && (deidentified || includedPatients.length > 0)) {
+      results.list = (await getResourceInfosFromBundle(
+        mainResources,
+        deidentified,
+        includedPatients,
+        includedEncounters
+      )) as T[]
+    } else {
+      results.list = (await getResourceInfos(mainResources, deidentified, groupId?.[0])) as T[]
+    }
   }
   results.total = list?.data?.resourceType === 'Bundle' ? (list.data.total ?? 0) : 0
   results.totalAllResults = all && all?.data?.resourceType === 'Bundle' ? (all.data.total ?? 0) : results.total

--- a/src/utils/fillElement.ts
+++ b/src/utils/fillElement.ts
@@ -5,6 +5,7 @@ import {
   Condition,
   DocumentReference,
   Encounter,
+  FhirResource,
   Identifier,
   ImagingStudy,
   MedicationAdministration,
@@ -205,7 +206,7 @@ export const isPatientResource = (resource: Resource | undefined): resource is P
   return resource?.resourceType === 'Patient'
 }
 
-export const getBundleResources = <T>(response: { data: FHIR_Bundle_Response<T> }): Resource[] => {
+export const getBundleResources = <T extends FhirResource>(response: { data: FHIR_Bundle_Response<T> }): Resource[] => {
   if (response.data.resourceType !== 'Bundle') return []
 
   return (

--- a/src/utils/fillElement.ts
+++ b/src/utils/fillElement.ts
@@ -12,7 +12,8 @@ import {
   Observation,
   Patient,
   Procedure,
-  QuestionnaireResponse
+  QuestionnaireResponse,
+  Resource
 } from 'fhir/r4'
 import { fetchPatient, fetchEncounter, fetchOrganization } from 'services/aphp/callApi'
 import {
@@ -22,7 +23,8 @@ import {
   CohortObservation,
   CohortPMSI,
   CohortQuestionnaireResponse,
-  FHIR_API_Response
+  FHIR_API_Response,
+  FHIR_Bundle_Response
 } from 'types'
 import { ResourceType } from 'types/requestCriterias'
 import { getApiResponseResources } from './apiHelpers'
@@ -193,6 +195,24 @@ const withDocumentOrganizations = async <U extends CohortResourceType>(filledEnt
   }
 
   return filledEntries
+}
+
+export const isEncounterResource = (resource: Resource | undefined): resource is Encounter => {
+  return resource?.resourceType === 'Encounter'
+}
+
+export const isPatientResource = (resource: Resource | undefined): resource is Patient => {
+  return resource?.resourceType === 'Patient'
+}
+
+export const getBundleResources = <T>(response: { data: FHIR_Bundle_Response<T> }): Resource[] => {
+  if (response.data.resourceType !== 'Bundle') return []
+
+  return (
+    response.data.entry
+      ?.map((entry) => entry.resource as unknown as Resource | undefined)
+      .filter((resource): resource is Resource => !!resource) ?? []
+  )
 }
 
 export const getResourceInfosFromBundle = async <T extends ResourceToFill, U extends CohortResourceType>(


### PR DESCRIPTION
## Objectif

fix: https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3237

Réduire le nombre d'appels réseau des vues d'exploration : au lieu de récupérer une liste puis d'aller chercher séparément les Patient et Encounter liés, on demande au serveur FHIR de les renvoyer dans le même bundle via _include.

## Changements réalisés

- Généralisation du mécanisme _include (déjà présent pour les documents) à toutes les ressources d'exploration : Observation, ImagingStudy, Condition, Procedure, Claim, MedicationRequest, MedicationAdministration, QuestionnaireResponse.
- Logique de tri/liaison du bundle mutualisée dans fetcherWithParams, avec bascule automatique sur getResourceInfosFromBundle et fallback sur getResourceInfos si le serveur ne renvoie pas les includes.
- Helpers partagés getBundleResources, isPatientResource, isEncounterResource (fillElement.ts) et addIncludeParams (callApi.ts).
- Consolidation : documents.ts et fetchDocumentReference utilisent désormais ces helpers partagés (suppression des copies locales).

## Impacts
Front 

## Tests réalisés
Unitaires,  manuel, 

## Risques
Pas de riques : Un fallback sur l'ancien comportement (getResourceInfos) est conservé si les includes ne reviennent pas.
