### PR TITLE
feat(onboarding): étape 1 découvrir votre environnement (#3306, #3307)

### DIFF
--- a/src/components/ui/InfoBadge/index.tsx
+++ b/src/components/ui/InfoBadge/index.tsx
@@ -1,0 +1,34 @@
+import { styled } from '@mui/material'
+import React from 'react'
+
+type InfoBadgeProps = {
+  size?: number
+  className?: string
+}
+
+const Ring = styled('span', { shouldForwardProp: (prop) => prop !== 'ringSize' })<{ ringSize: number }>(
+  ({ theme, ringSize }) => ({
+    flexShrink: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: ringSize,
+    height: ringSize,
+    borderRadius: '50%',
+    border: `${Math.round(ringSize / 5)}px solid ${theme.palette.primary.dark}`,
+    color: theme.palette.primary.dark,
+    fontFamily: 'Georgia, serif',
+    fontStyle: 'italic',
+    fontWeight: 700,
+    fontSize: Math.round(ringSize * 0.5),
+    lineHeight: 1
+  })
+)
+
+const InfoBadge = ({ size = 24, className }: InfoBadgeProps) => (
+  <Ring ringSize={size} className={className}>
+    i
+  </Ring>
+)
+
+export default InfoBadge

--- a/src/services/aphp/serviceOnboarding.ts
+++ b/src/services/aphp/serviceOnboarding.ts
@@ -1,6 +1,7 @@
 import type { AxiosResponse } from 'axios'
 
 import apiBackend from 'services/apiBackend'
+import type { MyAccess, RightCatalogCategory } from 'types'
 
 export type OnboardingProgress = {
   onboarding_step: number
@@ -9,10 +10,20 @@ export type OnboardingProgress = {
 
 export interface IServiceOnboarding {
   updateStep: (step: number) => Promise<AxiosResponse<OnboardingProgress>>
+  getMyAccesses: () => Promise<MyAccess[]>
+  getRightsCatalog: () => Promise<RightCatalogCategory[]>
 }
 
 const serviceOnboarding: IServiceOnboarding = {
-  updateStep: (step) => apiBackend.patch<OnboardingProgress>('/users/me/onboarding/', { onboarding_step: step })
+  updateStep: (step) => apiBackend.patch<OnboardingProgress>('/users/me/onboarding/', { onboarding_step: step }),
+  getMyAccesses: async () => {
+    const { data } = await apiBackend.get<MyAccess[]>('accesses/accesses/my-accesses/')
+    return data
+  },
+  getRightsCatalog: async () => {
+    const { data } = await apiBackend.get<RightCatalogCategory[]>('accesses/rights/')
+    return data
+  }
 }
 
 export default serviceOnboarding

--- a/src/types.ts
+++ b/src/types.ts
@@ -574,6 +574,30 @@ export type AccessExpiration = {
   perimeter: string
 }
 
+// The role carries a boolean flag per right (right_*); the catalog below provides their labels.
+export type MyAccessRole = {
+  name: string | null
+} & Record<string, boolean | string | null>
+
+export type MyAccess = {
+  id: number
+  role: MyAccessRole
+  perimeter: { source_value: string; name: string } | null
+  end_datetime: string | null
+}
+
+export type RightCatalogItem = {
+  name: string
+  label: string
+  depends_on: string | null
+}
+
+export type RightCatalogCategory = {
+  name: string
+  is_global: boolean
+  rights: RightCatalogItem[]
+}
+
 // this is an incomplete type, it should be completed with the other fields
 export type UserAccesses = {
   role: {

--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -26,9 +26,12 @@ const getInitials = (name?: string) =>
 const OnboardingLayout = () => {
   const { classes } = useStyles()
   const displayName = useAppSelector((state) => state.me?.displayName)
-  const { screen, currentStep, isLastStep, saving, error, goNext, goBack } = useOnboarding()
+  const { screen, currentStep, subStep, isLastStep, saving, error, goNext, goBack } = useOnboarding()
 
   const nextLabel = screen === 'welcome' ? 'Commencer' : isLastStep ? 'Terminer' : 'Continuer'
+
+  const activeStepConfig = ONBOARDING_STEPS[currentStep]
+  const ActiveScreen = activeStepConfig.screens?.[subStep]
 
   const header = (
     <>
@@ -62,7 +65,13 @@ const OnboardingLayout = () => {
       activeStep={screen === 'welcome' ? -1 : currentStep}
       footer={footer}
     >
-      {screen === 'welcome' ? <WelcomeScreen /> : <StepPlaceholder step={ONBOARDING_STEPS[currentStep]} />}
+      {screen === 'welcome' ? (
+        <WelcomeScreen />
+      ) : ActiveScreen ? (
+        <ActiveScreen />
+      ) : (
+        <StepPlaceholder step={activeStepConfig} />
+      )}
       {error && (
         <Typography role="alert" className={classes.error}>
           Une erreur est survenue lors de l'enregistrement de votre progression. Veuillez réessayer.

--- a/src/views/Onboarding/OnboardingContext.tsx
+++ b/src/views/Onboarding/OnboardingContext.tsx
@@ -4,13 +4,14 @@ import { createContext, useContext, useMemo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'state'
 import { advanceOnboarding, clearOnboardingError, ONBOARDING_TOTAL_STEPS } from 'state/onboarding'
 
-import { ONBOARDING_STEPS } from './steps'
+import { getStepScreenCount, ONBOARDING_STEPS } from './steps'
 
 type OnboardingScreen = 'welcome' | 'steps'
 
 type OnboardingContextValue = {
   screen: OnboardingScreen
   currentStep: number
+  subStep: number
   totalSteps: number
   saving: boolean
   error: boolean
@@ -34,11 +35,14 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
   const { saving, error } = useAppSelector((state) => state.onboarding)
 
   const [currentStep, setCurrentStep] = useState(() => clampStep(initialStep))
+  const [subStep, setSubStep] = useState(0)
   const [screen, setScreen] = useState<OnboardingScreen>(() => (initialStep <= 0 ? 'welcome' : 'steps'))
 
   const value = useMemo<OnboardingContextValue>(() => {
-    const isFirstStep = currentStep === 0
-    const isLastStep = currentStep === ONBOARDING_STEPS.length - 1
+    const screenCount = getStepScreenCount(currentStep)
+    const isLastMacroStep = currentStep === ONBOARDING_STEPS.length - 1
+    const isFirstStep = currentStep === 0 && subStep === 0
+    const isLastStep = isLastMacroStep && subStep === screenCount - 1
 
     const goNext = () => {
       if (saving) {
@@ -48,9 +52,15 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
         setScreen('steps')
         return
       }
+      // Progress is persisted per macro step, only once its last screen is left.
+      if (subStep < screenCount - 1) {
+        setSubStep((step) => step + 1)
+        return
+      }
       dispatch(advanceOnboarding(currentStep + 1))
-      if (!isLastStep) {
+      if (!isLastMacroStep) {
         setCurrentStep((step) => step + 1)
+        setSubStep(0)
       }
     }
 
@@ -61,16 +71,23 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
       if (error) {
         dispatch(clearOnboardingError())
       }
-      if (isFirstStep) {
+      if (subStep > 0) {
+        setSubStep((step) => step - 1)
+        return
+      }
+      if (currentStep === 0) {
         setScreen('welcome')
         return
       }
-      setCurrentStep((step) => step - 1)
+      const previousStep = currentStep - 1
+      setCurrentStep(previousStep)
+      setSubStep(getStepScreenCount(previousStep) - 1)
     }
 
     return {
       screen,
       currentStep,
+      subStep,
       totalSteps: ONBOARDING_STEPS.length,
       saving,
       error,
@@ -79,7 +96,7 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
       goNext,
       goBack
     }
-  }, [screen, currentStep, saving, error, dispatch])
+  }, [screen, currentStep, subStep, saving, error, dispatch])
 
   return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>
 }

--- a/src/views/Onboarding/__tests__/OnboardingContext.test.tsx
+++ b/src/views/Onboarding/__tests__/OnboardingContext.test.tsx
@@ -43,14 +43,50 @@ describe('OnboardingContext', () => {
     expect(updateStep).not.toHaveBeenCalled()
   })
 
-  it('persists the completed step and advances when continuing', async () => {
+  it('navigates the screens of a macro step without persisting until it is left', async () => {
     const { result } = renderOnboarding(0)
+    act(() => result.current.goNext()) // welcome -> first screen of step 0
+    expect(result.current.currentStep).toBe(0)
+    expect(result.current.subStep).toBe(0)
+
+    // The environment step is made of four screens (three from 3306, one from 3307).
     act(() => result.current.goNext())
+    expect(result.current.subStep).toBe(1)
+    expect(updateStep).not.toHaveBeenCalled()
+
+    act(() => result.current.goNext())
+    act(() => result.current.goNext())
+    expect(result.current.subStep).toBe(3)
+    expect(updateStep).not.toHaveBeenCalled()
+  })
+
+  it('persists the completed step and advances when leaving the last screen of a macro step', async () => {
+    const { result } = renderOnboarding(0)
+    act(() => result.current.goNext()) // welcome -> screen 0
+    act(() => result.current.goNext()) // screen 1
+    act(() => result.current.goNext()) // screen 2
+    act(() => result.current.goNext()) // screen 3 (last of step 0)
     await act(async () => {
-      result.current.goNext()
+      result.current.goNext() // leaves step 0
     })
     expect(updateStep).toHaveBeenCalledWith(1)
     expect(result.current.currentStep).toBe(1)
+    expect(result.current.subStep).toBe(0)
+  })
+
+  it('steps back through screens then to the previous macro step', async () => {
+    const { result } = renderOnboarding(0)
+    for (let i = 0; i < 5; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        result.current.goNext()
+      })
+    }
+    // Now on the last screen of step 1 boundary; walk back into step 0.
+    expect(result.current.currentStep).toBe(1)
+    act(() => result.current.goBack())
+    expect(result.current.currentStep).toBe(0)
+    expect(result.current.subStep).toBe(3)
   })
 
   it('resumes directly at the persisted macro step (RG3305.06)', () => {

--- a/src/views/Onboarding/screens/DataAccess.tsx
+++ b/src/views/Onboarding/screens/DataAccess.tsx
@@ -1,0 +1,35 @@
+import { Box, Typography } from '@mui/material'
+import React from 'react'
+
+import useStyles from '../styles'
+
+const DataAccess = () => {
+  const { classes } = useStyles()
+
+  return (
+    <Box>
+      <Typography variant="h4" className={classes.title}>
+        L'accès aux données de l'EDS
+      </Typography>
+      <Typography className={classes.sectionText}>
+        Votre accès aux données via Cohort360 est déterminé par des <strong>droits d'habilitation</strong> appliqués à
+        un <strong>périmètre de données</strong> accessibles.
+      </Typography>
+      <Typography className={classes.sectionText}>
+        Votre périmètre d'accès dépend des unités fonctionnelles ou hôpitaux auxquelles vous avez été habilité.
+      </Typography>
+      <ul className={classes.list}>
+        <li>
+          <strong>Cas général :</strong> vous êtes rattaché à une ou plusieurs unités fonctionnelles : vous avez accès
+          aux patients pris en charge par cette ou ces unités fonctionnelles.
+        </li>
+        <li>
+          <strong>Recherche multicentrique :</strong> votre accès est limité aux unités fonctionnelles validées dans le
+          cadre de votre projet de recherche.
+        </li>
+      </ul>
+    </Box>
+  )
+}
+
+export default DataAccess

--- a/src/views/Onboarding/screens/UserRights.tsx
+++ b/src/views/Onboarding/screens/UserRights.tsx
@@ -1,0 +1,88 @@
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { Box, CircularProgress, Typography } from '@mui/material'
+import moment from 'moment'
+import React from 'react'
+
+import { useAppSelector } from 'state'
+
+import useStyles from '../styles'
+import { useUserAccesses } from './useUserAccesses'
+
+const UserRights = () => {
+  const { classes } = useStyles()
+  const displayName = useAppSelector((state) => state.me?.displayName)
+  const { loading, hasError, accesses } = useUserAccesses()
+
+  const title = (
+    <Typography variant="h4" className={classes.title}>
+      Comprendre votre accès
+    </Typography>
+  )
+
+  if (loading) {
+    return (
+      <Box>
+        {title}
+        <Box className={classes.loadingRow}>
+          <CircularProgress size={24} />
+        </Box>
+      </Box>
+    )
+  }
+
+  if (hasError) {
+    return (
+      <Box>
+        {title}
+        <Typography role="alert" className={classes.error}>
+          Une erreur est survenue lors de la récupération de vos droits d'accès. Veuillez réessayer ultérieurement.
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      {title}
+      <Box className={classes.fieldBlock}>
+        <Typography className={classes.fieldLabel}>Utilisateur :</Typography>
+        <Typography className={classes.fieldValue}>{displayName}</Typography>
+      </Box>
+
+      <Box className={classes.tileGrid}>
+        {accesses.map((access) => (
+          <Box key={access.id} className={classes.tile}>
+            <Box className={classes.fieldBlock}>
+              <Typography className={classes.fieldLabel}>Votre profil :</Typography>
+              <Typography className={classes.fieldValue}>{access.profile}</Typography>
+            </Box>
+
+            <Box className={classes.fieldBlock}>
+              <Typography className={classes.fieldLabel}>Vos droits :</Typography>
+              {access.rights.map((right) => (
+                <Box key={right} className={classes.rightItem}>
+                  <CheckCircleIcon className={classes.checkIcon} fontSize="small" />
+                  <Typography className={classes.rightLabel}>{right}</Typography>
+                </Box>
+              ))}
+            </Box>
+
+            <Box className={classes.fieldBlock}>
+              <Typography className={classes.fieldLabel}>Votre périmètre des données accessibles :</Typography>
+              <Typography className={classes.fieldValue}>{access.perimeter}</Typography>
+            </Box>
+
+            <Box className={classes.fieldBlock}>
+              <Typography className={classes.fieldLabel}>Date d'expiration de votre accès à Cohort360 :</Typography>
+              <Typography className={classes.fieldValue}>
+                {access.expirationDate ? moment(access.expirationDate).format('DD/MM/YYYY') : 'Non renseignée'}
+              </Typography>
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export default UserRights

--- a/src/views/Onboarding/screens/WhatIsCohort360.tsx
+++ b/src/views/Onboarding/screens/WhatIsCohort360.tsx
@@ -1,0 +1,25 @@
+import { Box, Typography } from '@mui/material'
+import React from 'react'
+
+import useStyles from '../styles'
+
+const WhatIsCohort360 = () => {
+  const { classes } = useStyles()
+
+  return (
+    <Box>
+      <Typography variant="h4" className={classes.title}>
+        Qu'est-ce que Cohort360 ?
+      </Typography>
+      <Typography className={classes.sectionText}>
+        Cohort360 est un outil qui permet aux professionnels de santé de l'AP-HP{' '}
+        <strong>
+          de créer et de visualiser les données de groupes de patients (cohortes) en fonction de divers critères
+        </strong>
+        .
+      </Typography>
+    </Box>
+  )
+}
+
+export default WhatIsCohort360

--- a/src/views/Onboarding/screens/WhatIsEds.tsx
+++ b/src/views/Onboarding/screens/WhatIsEds.tsx
@@ -1,0 +1,96 @@
+import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined'
+import BiotechOutlinedIcon from '@mui/icons-material/BiotechOutlined'
+import ContactPageOutlinedIcon from '@mui/icons-material/ContactPageOutlined'
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined'
+import MedicationOutlinedIcon from '@mui/icons-material/MedicationOutlined'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { Box, Divider, Link, Typography } from '@mui/material'
+import type { SvgIconProps } from '@mui/material'
+import InfoBadge from 'components/ui/InfoBadge'
+import type { ComponentType } from 'react'
+import React from 'react'
+
+import useStyles from '../styles'
+
+const EDS_URL = 'https://eds.aphp.fr/'
+
+type DataFamily = {
+  label: string
+  description: string
+  icon: ComponentType<SvgIconProps>
+}
+
+const DATA_FAMILIES: DataFamily[] = [
+  {
+    label: 'Socio-démographie des patients',
+    description: 'Date de naissance, sexe, zone de résidence, statut vital…',
+    icon: ContactPageOutlinedIcon
+  },
+  {
+    label: 'Médico-administratif',
+    description: 'Diagnostics, actes, séjours des patients…',
+    icon: AssignmentOutlinedIcon
+  },
+  {
+    label: 'Médicaments',
+    description: 'Prescriptions, administrations',
+    icon: MedicationOutlinedIcon
+  },
+  {
+    label: "Résultats d'examen",
+    description: 'Biologie, imagerie',
+    icon: BiotechOutlinedIcon
+  },
+  {
+    label: 'Documents médicaux',
+    description: "Comptes rendus d'examen, d'hospitalisation, de consultation, lettres de liaison…",
+    icon: DescriptionOutlinedIcon
+  }
+]
+
+const WhatIsEds = () => {
+  const { classes } = useStyles()
+
+  return (
+    <Box>
+      <Typography variant="h4" className={classes.title}>
+        Qu'est-ce que l'EDS ?
+      </Typography>
+      <Typography className={classes.sectionText}>
+        Cohort360 permet d'accéder à de nombreux{' '}
+        <strong>jeux de données, issues de l'Entrepôt de Données de Santé de l'AP-HP (EDS)</strong>. L'EDS centralise
+        toutes les données collectées dans les 38 hôpitaux de l'AP-HP.
+      </Typography>
+      <Box className={classes.linkRow}>
+        <Link className={classes.link} href={EDS_URL} target="_blank" rel="noopener noreferrer">
+          En savoir plus sur l'EDS
+          <OpenInNewIcon className={classes.linkIcon} fontSize="inherit" />
+        </Link>
+      </Box>
+
+      <Typography className={classes.subTitle}>Les données de l'EDS</Typography>
+      {DATA_FAMILIES.map(({ label, description, icon: Icon }) => (
+        <Box key={label} className={classes.stepRow}>
+          <Box className={classes.iconBox}>
+            <Icon fontSize="small" />
+          </Box>
+          <Box>
+            <Typography className={classes.stepTitle}>{label}</Typography>
+            <Typography className={classes.stepDesc}>{description}</Typography>
+          </Box>
+        </Box>
+      ))}
+
+      <Divider className={classes.divider} />
+      <Box className={classes.infoRow}>
+        <InfoBadge className={classes.infoBadge} />
+        <Typography className={classes.infoText}>
+          Selon votre profil d'habilitation, vous accédez à des données nominatives (identité des patients visible) ou
+          pseudonymisées (identité masquée).
+        </Typography>
+      </Box>
+    </Box>
+  )
+}
+
+export default WhatIsEds

--- a/src/views/Onboarding/screens/__tests__/UserRights.test.tsx
+++ b/src/views/Onboarding/screens/__tests__/UserRights.test.tsx
@@ -1,0 +1,118 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getMyAccesses = vi.fn()
+const getRightsCatalog = vi.fn()
+
+vi.mock('services/aphp/serviceOnboarding', () => ({
+  default: { getMyAccesses: () => getMyAccesses(), getRightsCatalog: () => getRightsCatalog() }
+}))
+
+import meReducer, { type MeState } from 'state/me'
+import type { MyAccess, RightCatalogCategory } from 'types'
+import UserRights from '../UserRights'
+
+const CATALOG: RightCatalogCategory[] = [
+  {
+    name: 'Lecture de données patient',
+    is_global: false,
+    rights: [
+      { name: 'right_read_patient_nominative', label: 'Lecture de données patient nominatives', depends_on: null },
+      { name: 'right_read_patient_pseudonymized', label: 'Lecture de données patient pseudonymisées', depends_on: null }
+    ]
+  },
+  {
+    name: 'Recherche de patients',
+    is_global: true,
+    rights: [{ name: 'right_search_patients_by_ipp', label: 'Chercher les patients par IPP', depends_on: null }]
+  },
+  {
+    name: 'Logs',
+    is_global: true,
+    rights: [{ name: 'right_read_logs', label: 'Consulter les logs', depends_on: null }]
+  }
+]
+
+const access = (overrides: Partial<MyAccess> = {}): MyAccess => ({
+  id: 1,
+  role: {
+    name: 'ADMIN CENTRAL',
+    right_read_patient_nominative: true,
+    right_read_patient_pseudonymized: true,
+    right_search_patients_by_ipp: true,
+    right_read_logs: false
+  },
+  perimeter: { source_value: '072', name: 'HOPITAL ROTHSCHILD' },
+  end_datetime: '2027-04-20T00:00:00Z',
+  ...overrides
+})
+
+const baseMe = { displayName: 'Cesar RICHARD' } as MeState
+
+const renderUserRights = (me: MeState = baseMe) => {
+  const store = configureStore({ reducer: { me: meReducer }, preloadedState: { me } })
+  return render(
+    <Provider store={store}>
+      <UserRights />
+    </Provider>
+  )
+}
+
+describe('UserRights (US-3307)', () => {
+  beforeEach(() => {
+    getMyAccesses.mockReset()
+    getRightsCatalog.mockReset()
+    getMyAccesses.mockResolvedValue([access()])
+    getRightsCatalog.mockResolvedValue(CATALOG)
+  })
+
+  it('shows the user, habilitation name as profile, granted rights (catalog labels), perimeter and expiration', async () => {
+    renderUserRights()
+    expect(await screen.findByText('ADMIN CENTRAL')).toBeInTheDocument()
+    expect(screen.getByText('Cesar RICHARD')).toBeInTheDocument()
+    expect(screen.getByText('Lecture de données patient nominatives')).toBeInTheDocument()
+    expect(screen.getByText('Lecture de données patient pseudonymisées')).toBeInTheDocument()
+    expect(screen.getByText('Chercher les patients par IPP')).toBeInTheDocument()
+    expect(screen.getByText('072 - HOPITAL ROTHSCHILD')).toBeInTheDocument()
+    expect(screen.getByText('20/04/2027')).toBeInTheDocument()
+  })
+
+  it('lists only granted rights (a non-granted right is not shown)', async () => {
+    renderUserRights()
+    await screen.findByText('ADMIN CENTRAL')
+    expect(screen.queryByText('Consulter les logs')).not.toBeInTheDocument()
+  })
+
+  it('renders one tile per access (RG3307.03)', async () => {
+    getMyAccesses.mockResolvedValue([
+      access(),
+      access({
+        id: 2,
+        role: { name: 'droit faible pour test', right_read_patient_pseudonymized: true },
+        perimeter: { source_value: 'UPS', name: 'AP-HP.UNIVERSITE PARIS SACLAY' },
+        end_datetime: '2026-08-07T00:00:00Z'
+      })
+    ])
+    renderUserRights()
+
+    expect(await screen.findByText('ADMIN CENTRAL')).toBeInTheDocument()
+    expect(screen.getByText('droit faible pour test')).toBeInTheDocument()
+    expect(screen.getByText('UPS - AP-HP.UNIVERSITE PARIS SACLAY')).toBeInTheDocument()
+    expect(screen.getByText('07/08/2026')).toBeInTheDocument()
+  })
+
+  it('falls back gracefully when no expiration date is available', async () => {
+    getMyAccesses.mockResolvedValue([access({ end_datetime: null })])
+    renderUserRights()
+    expect(await screen.findByText('Non renseignée')).toBeInTheDocument()
+  })
+
+  it('shows an error message when a call fails', async () => {
+    getRightsCatalog.mockRejectedValue(new Error('boom'))
+    renderUserRights()
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Une erreur est survenue/)
+  })
+})

--- a/src/views/Onboarding/screens/useUserAccesses.ts
+++ b/src/views/Onboarding/screens/useUserAccesses.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+
+import serviceOnboarding from 'services/aphp/serviceOnboarding'
+import type { MyAccess, MyAccessRole, RightCatalogCategory } from 'types'
+
+export type UserAccess = {
+  id: number
+  perimeter: string
+  profile: string
+  rights: string[]
+  expirationDate?: Date
+}
+
+type FlatRight = [name: string, label: string]
+
+const flattenCatalog = (catalog: RightCatalogCategory[]): FlatRight[] =>
+  catalog.flatMap((category) => category.rights.map((right): FlatRight => [right.name, right.label]))
+
+const grantedRightsLabels = (role: MyAccessRole, catalog: FlatRight[]): string[] =>
+  catalog.filter(([key]) => role[key] === true).map(([, label]) => label)
+
+const toUserAccess = (access: MyAccess, catalog: FlatRight[]): UserAccess => ({
+  id: access.id,
+  perimeter: access.perimeter ? `${access.perimeter.source_value} - ${access.perimeter.name}` : '',
+  profile: access.role?.name ?? '',
+  rights: access.role ? grantedRightsLabels(access.role, catalog) : [],
+  expirationDate: access.end_datetime ? new Date(access.end_datetime) : undefined
+})
+
+type UserAccessesState = {
+  loading: boolean
+  hasError: boolean
+  accesses: UserAccess[]
+}
+
+// Profile is the habilitation name and rights are labelled from the catalog, to mirror the admin portal.
+export const useUserAccesses = (): UserAccessesState => {
+  const [accesses, setAccesses] = useState<UserAccess[]>([])
+  const [loading, setLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    Promise.all([serviceOnboarding.getMyAccesses(), serviceOnboarding.getRightsCatalog()])
+      .then(([myAccesses, catalog]) => {
+        if (active) {
+          const flatCatalog = flattenCatalog(catalog)
+          setAccesses(myAccesses.map((access) => toUserAccess(access, flatCatalog)))
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setHasError(true)
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false)
+        }
+      })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return { loading, hasError, accesses }
+}

--- a/src/views/Onboarding/steps.ts
+++ b/src/views/Onboarding/steps.ts
@@ -4,11 +4,17 @@ import MenuBookIcon from '@mui/icons-material/MenuBook'
 import type { SvgIconProps } from '@mui/material'
 import type { ComponentType } from 'react'
 
+import DataAccess from './screens/DataAccess'
+import UserRights from './screens/UserRights'
+import WhatIsCohort360 from './screens/WhatIsCohort360'
+import WhatIsEds from './screens/WhatIsEds'
+
 export type OnboardingStepConfig = {
   key: string
   label: string
   summary: string
   icon: ComponentType<SvgIconProps>
+  screens?: ComponentType[]
 }
 
 export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
@@ -16,7 +22,8 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
     key: 'environment',
     label: 'Découvrir votre environnement',
     summary: 'Apprenez-en plus sur ce qu’est Cohort360 et sur vos accès aux données dans l’outil.',
-    icon: MenuBookIcon
+    icon: MenuBookIcon,
+    screens: [WhatIsCohort360, WhatIsEds, DataAccess, UserRights]
   },
   {
     key: 'commitments',
@@ -31,3 +38,5 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
     icon: FormatListBulletedIcon
   }
 ]
+
+export const getStepScreenCount = (stepIndex: number): number => ONBOARDING_STEPS[stepIndex]?.screens?.length ?? 1

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -130,6 +130,99 @@ const useStyles = makeStyles()((theme: Theme) => ({
   error: {
     marginTop: theme.spacing(2),
     color: theme.palette.error.main
+  },
+  sectionText: {
+    color: T.muted,
+    marginTop: theme.spacing(2),
+    lineHeight: 1.6
+  },
+  subTitle: {
+    color: T.ink,
+    fontWeight: 700,
+    marginTop: theme.spacing(3)
+  },
+  list: {
+    color: T.muted,
+    marginTop: theme.spacing(1.5),
+    paddingLeft: theme.spacing(3),
+    lineHeight: 1.6,
+    '& li': {
+      marginTop: theme.spacing(0.5)
+    }
+  },
+  link: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    color: theme.palette.primary.main,
+    fontWeight: 600,
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'underline'
+    }
+  },
+  linkIcon: {
+    fontSize: 16
+  },
+  linkRow: {
+    marginTop: theme.spacing(2)
+  },
+  divider: {
+    marginTop: theme.spacing(3)
+  },
+  infoRow: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1.5),
+    marginTop: theme.spacing(3)
+  },
+  infoBadge: {
+    marginTop: theme.spacing(0.25)
+  },
+  infoText: {
+    color: theme.palette.primary.main,
+    lineHeight: 1.6
+  },
+  loadingRow: {
+    display: 'flex',
+    justifyContent: 'center',
+    marginTop: theme.spacing(4)
+  },
+  fieldBlock: {
+    marginTop: theme.spacing(3)
+  },
+  fieldLabel: {
+    color: T.muted
+  },
+  fieldValue: {
+    color: T.ink,
+    fontWeight: 700
+  },
+  rightItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    marginTop: theme.spacing(1.5)
+  },
+  checkIcon: {
+    flexShrink: 0,
+    color: theme.palette.success.main
+  },
+  rightLabel: {
+    color: T.ink,
+    fontWeight: 700
+  },
+  tileGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(2)
+  },
+  tile: {
+    border: `1px solid ${T.cardBorder}`,
+    borderRadius: 6,
+    padding: theme.spacing(1, 3, 3),
+    backgroundColor: T.tileBg
   }
 }))
 

--- a/src/views/Onboarding/tokens.ts
+++ b/src/views/Onboarding/tokens.ts
@@ -9,5 +9,6 @@ export const onboardingTokens = {
   stepIconFg: '#C77B3B',
   avatarBg: '#5BC5F2',
   stepCircleBorder: '#C4D3E8',
-  stepCircleInactive: '#9AA7B8'
+  stepCircleInactive: '#9AA7B8',
+  tileBg: '#F5F8FE'
 } as const


### PR DESCRIPTION
## Objectif
Livrer l'étape 1 « Découvrir votre environnement » du parcours onboarding : présentation de Cohort360 et de l'EDS, puis récapitulatif personnalisé des accès de l'utilisateur.

Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3306
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3307

## Changements réalisés
Sous-navigation interne à l'étape (le shell #3305 gère une étape = un écran ; l'étape 1 enchaîne désormais 4 écrans, la progression reste persistée par étape macro). Écrans statiques 3306 (Cohort360 / EDS avec ses 5 familles de données et le lien externe / accès aux données). Écran 3307 « Comprendre votre accès » : profil (habilitation), périmètre, date d'expiration et liste des droits accordés, une tuile par accès. Les données viennent de `my-accesses` et du catalogue `accesses/rights` (libellés identiques au Portail Admin). Nouveau composant réutilisable `ui/InfoBadge`.

## Impacts
Front uniquement. Consomme les endpoints existants `accesses/accesses/my-accesses/` et `accesses/rights/` (lecture seule).

## Tests réalisés
Tests unitaires (sous-navigation du contexte, écran 3307 : profil/droits/périmètre/date, multi-tuiles, état d'erreur, date absente). tsc et eslint OK. Test manuel du parcours en local avec accès réels comparés au Portail Admin.

## Risques
Le récap 3307 affiche l'intégralité des droits de l'habilitation (choix produit à confirmer avec le PO, la maquette initiale montrait une liste réduite). La maquette de l'état d'erreur reste à fournir.