### PR TITLE
feat(fhir): Modify fhir filter

### DIFF
--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/buildMappers.ts
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/buildMappers.ts
@@ -216,6 +216,10 @@ const buildRaw = (value: string) => {
   return value
 }
 
+const buildBooleanConstantFilter = (checked: boolean | null, constantValue?: string) => {
+  return checked && constantValue ? constantValue : ''
+}
+
 const buildSearchFilter = (criterion: string) => {
   return criterion ? `${encodeURIComponent(criterion)}` : ''
 }
@@ -383,5 +387,7 @@ export const BUILD_MAPPERS = {
     buildWithDocumentFilter(val as string, args[0] as number | null),
   buildRaw: (val: DataTypes, key: FhirKey, deidentified: boolean, args: Array<DataTypes | BuilderMethod>) =>
     buildRaw(val as string),
+  buildBooleanConstant: (val: DataTypes, key: FhirKey, deidentified: boolean, args: Array<DataTypes | BuilderMethod>) =>
+    buildBooleanConstantFilter(val as boolean, args[0] as string),
   noop: (val: DataTypes, key: FhirKey, deidentified: boolean, args: Array<DataTypes | BuilderMethod>) => undefined
 }

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper.tsx
@@ -349,6 +349,12 @@ export const CHIPS_DISPLAY_METHODS = {
     valueSets: ValueSetStore,
     args: Array<ChipDisplayMethod | DataTypes>
   ) => getDocumentStatusLabel(val as LabelObject[]),
+  getDocumentImportedExclusionLabel: (
+    val: DataTypes,
+    item: GenericCriteriaItem,
+    valueSets: ValueSetStore,
+    args: Array<ChipDisplayMethod | DataTypes>
+  ) => (val ? 'Documents importés exclus' : null),
   altArgs: (
     val: DataTypes,
     item: GenericCriteriaItem,

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/index.ts
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/index.ts
@@ -236,6 +236,16 @@ export const constructFhirFilterForType = <T extends SelectedCriteriaType>(
       criteriaForm.buildInfo.defaultFilter ?? ''
     )
 }
+const resetPresenceBasedBooleans = <T extends SelectedCriteriaType>(
+  criterion: T,
+  items: Array<{ valueKey?: keyof T; buildInfo?: { unbuildMethod?: string } }>
+): void => {
+  for (const item of items) {
+    if (item.valueKey && item.buildInfo?.unbuildMethod === 'unbuildBooleanFromDataNonNullStatus') {
+      criterion[item.valueKey] = false as T[keyof T]
+    }
+  }
+}
 
 export const unbuildCriteriaDataFromDefinition = async <T extends SelectedCriteriaType>(
   element: RequeteurCriteriaType,
@@ -262,6 +272,7 @@ export const unbuildCriteriaDataFromDefinition = async <T extends SelectedCriter
   }
 
   const criteriaItems = criteriaDefinition.itemSections.flatMap((section) => section.items)
+  resetPresenceBasedBooleans(emptyCriterion, criteriaItems)
   if (element.filterFhir) {
     const filters = element.filterFhir.split('&').map((elem) => elem.split('='))
     try {

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/forms/DocumentsForm.ts
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/forms/DocumentsForm.ts
@@ -21,6 +21,7 @@ export type DocumentDataType = CommonCriteriaData &
     searchBy: string | null
     docType: string[] | null
     docStatuses: string[] | null
+    excludeImportedDocuments: boolean
   }
 
 export const form: () => CriteriaForm<DocumentDataType> = () => ({
@@ -40,13 +41,13 @@ export const form: () => CriteriaForm<DocumentDataType> = () => ({
     search: '',
     searchBy: SearchByTypes.TEXT,
     docType: null,
-    docStatuses: null
+    docStatuses: null,
+    excludeImportedDocuments: true
   },
   infoAlert: ['Tous les éléments des champs multiples sont liés par une contrainte OU'],
   buildInfo: {
     type: { [ResourceType.DOCUMENTS]: CriteriaType.DOCUMENTS },
-    defaultFilter:
-      'type:not=doc-impor&contenttype=text/plain' + (getConfig().core.fhir.filterActive ? '&subject.active=true' : '')
+    defaultFilter: 'contenttype=text/plain' + (getConfig().core.fhir.filterActive ? '&subject.active=true' : '')
   },
   itemSections: [
     {
@@ -152,6 +153,18 @@ export const form: () => CriteriaForm<DocumentDataType> = () => ({
           buildInfo: {
             fhirKey: DocumentsParamsKeys.ENCOUNTER_STATUS,
             chipDisplayMethodExtraArgs: [{ type: 'string', value: 'Statut de la visite associée :' }]
+          }
+        },
+        {
+          valueKey: 'excludeImportedDocuments',
+          type: 'boolean',
+          label: 'Exclure les documents importés',
+          buildInfo: {
+            fhirKey: `${DocumentsParamsKeys.DOC_TYPES}:not`,
+            buildMethod: 'buildBooleanConstant',
+            buildMethodExtraArgs: [{ type: 'string', value: 'doc-impor' }],
+            unbuildMethod: 'unbuildBooleanFromDataNonNullStatus',
+            chipDisplayMethod: 'getDocumentImportedExclusionLabel'
           }
         }
       ]

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/forms/PregnancyForm.ts
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/forms/PregnancyForm.ts
@@ -292,9 +292,9 @@ export const form: () => CriteriaForm<PregnancyDataType> = () => ({
             fhirKey: {
               id: 'F_MATER_001661',
               type: 'valueBoolean'
-            }
-          },
-          chipDisplayMethodExtraArgs: [{ type: 'string', value: 'Diagnostic prénatal :' }]
+            },
+            chipDisplayMethodExtraArgs: [{ type: 'string', value: 'Diagnostic prénatal :' }]
+          }
         }
       ]
     }

--- a/src/components/ExplorationBoard/Filters/index.tsx
+++ b/src/components/ExplorationBoard/Filters/index.tsx
@@ -42,6 +42,13 @@ const documentsStatusOptions = [
   }
 ]
 
+const excludeImportedDocumentsOptions = [
+  {
+    id: 'excludeImportedDocuments',
+    label: 'Exclure les documents importés'
+  }
+]
+
 const docStatusesList = [
   { id: FilterByDocumentStatus.VALIDATED, label: FilterByDocumentStatus.VALIDATED },
   { id: FilterByDocumentStatus.NOT_VALIDATED, label: FilterByDocumentStatus.NOT_VALIDATED }
@@ -109,6 +116,13 @@ const ExplorationFilters = ({ filters, infos, onChange, onError, hasChanged }: E
           onChange={(newValue) => field.onChange(newValue.includes('onlyPdfAvailable'))}
           value={field.value ? ['onlyPdfAvailable'] : []}
           options={documentsStatusOptions}
+        />
+      ),
+      [FilterKeys.EXCLUDE_IMPORTED_DOCUMENTS]: ({ field }) => (
+        <CheckboxGroup
+          onChange={(newValue) => field.onChange(newValue.includes('excludeImportedDocuments'))}
+          value={field.value ? ['excludeImportedDocuments'] : []}
+          options={excludeImportedDocumentsOptions}
         />
       ),
       [FilterKeys.GENDERS]: ({ field }) => <CheckboxGroup {...field} label="Genre :" options={genderOptions} />,

--- a/src/components/ExplorationBoard/config/documents.ts
+++ b/src/components/ExplorationBoard/config/documents.ts
@@ -58,6 +58,7 @@ const initSearchCriterias = (search: string): SearchCriterias<DocumentsFilters> 
     docStatuses: [],
     docTypes: [],
     onlyPdfAvailable: true,
+    excludeImportedDocuments: true,
     durationRange: [null, null],
     executiveUnits: [],
     encounterStatus: []
@@ -72,7 +73,17 @@ const fetchList = (
   groupId: string[],
   signal?: AbortSignal
 ): Promise<ExplorationResults<DocumentReference>> => {
-  const { nda, ipp, executiveUnits, encounterStatus, durationRange, docStatuses, docTypes, onlyPdfAvailable } = filters
+  const {
+    nda,
+    ipp,
+    executiveUnits,
+    encounterStatus,
+    durationRange,
+    docStatuses,
+    docTypes,
+    onlyPdfAvailable,
+    excludeImportedDocuments
+  } = filters
   const { searchInput } = fetchParams
   const params = {
     searchBy: searchBy,
@@ -84,6 +95,7 @@ const fetchList = (
     'encounter-identifier': nda,
     'patient-identifier': ipp,
     onlyPdfAvailable,
+    excludeImportedDocuments,
     uniqueFacet: ['subject'] as 'subject'[],
     executiveUnits: executiveUnits.map((unit) => unit.id),
     encounterStatus: encounterStatus?.map(({ id }) => id),
@@ -98,6 +110,7 @@ const fetchList = (
   }
   const paramsFetchAll = {
     patient: patient?.id,
+    excludeImportedDocuments,
     uniqueFacet: ['subject'] as 'subject'[],
     ...getCommonParamsAll(groupId),
     signal

--- a/src/mappers/filters.ts
+++ b/src/mappers/filters.ts
@@ -186,11 +186,22 @@ const mapDocumentsFromRequestParams = async (parameters: URLSearchParams) => {
       }))
   }
   const onlyPdfAvailable = true
+  const excludeImportedDocuments = parameters.has(`${DocumentsParamsKeys.DOC_TYPES}:not`)
   const { nda, durationRange, executiveUnits, encounterStatus } = await mapGenericFromRequestParams(
     parameters,
     ResourceType.DOCUMENTS
   )
-  return { docStatuses, docTypes, ipp, onlyPdfAvailable, nda, durationRange, executiveUnits, encounterStatus }
+  return {
+    docStatuses,
+    docTypes,
+    ipp,
+    onlyPdfAvailable,
+    excludeImportedDocuments,
+    nda,
+    durationRange,
+    executiveUnits,
+    encounterStatus
+  }
 }
 
 const mapConditionFromRequestParams = async (parameters: URLSearchParams) => {
@@ -401,9 +412,16 @@ const mapPatientToRequestParams = (filters: PatientsFilters, deidentified: boole
 }
 
 const mapDocumentsToRequestParams = (filters: DocumentsFilters) => {
-  const { ipp, docStatuses, docTypes, nda, durationRange, executiveUnits, encounterStatus } = filters
+  const { ipp, docStatuses, docTypes, nda, durationRange, executiveUnits, encounterStatus, excludeImportedDocuments } =
+    filters
   const docStatusCodeSystem = getConfig().core.codeSystems.docStatus
   const requestParams: string[] = []
+  if (excludeImportedDocuments)
+    requestParams.push(
+      `${DocumentsParamsKeys.DOC_TYPES}:not=${encodeURIComponent(
+        'https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor'
+      )}`
+    )
   if (ipp) requestParams.push(`${DocumentsParamsKeys.IPP}=${encodeURIComponent(ipp)}`)
   if (docStatuses && docStatuses.length > 0) {
     requestParams.push(

--- a/src/pages/ExportRequest/components/exportUtils.ts
+++ b/src/pages/ExportRequest/components/exportUtils.ts
@@ -248,8 +248,16 @@ const fetchDocumentsCount = async (cohortId: string, documentsFilters?: SearchCr
   try {
     let docResp
     if (documentsFilters && documentsFilters !== null) {
-      const { nda, durationRange, executiveUnits, encounterStatus, ipp, docTypes, docStatuses } =
-        documentsFilters.filters
+      const {
+        nda,
+        durationRange,
+        executiveUnits,
+        encounterStatus,
+        ipp,
+        docTypes,
+        docStatuses,
+        excludeImportedDocuments
+      } = documentsFilters.filters
 
       docResp = await fetchDocumentReference({
         size: 0,
@@ -260,6 +268,7 @@ const fetchDocumentsCount = async (cohortId: string, documentsFilters?: SearchCr
         type: docTypes.map((docType) => docType.code).join(),
         'encounter-identifier': nda,
         'patient-identifier': ipp,
+        excludeImportedDocuments,
         minDate: durationRange[0] ?? '',
         maxDate: durationRange[1] ?? '',
         executiveUnits: executiveUnits.map((unit) => unit.id),

--- a/src/services/aphp/callApi.ts
+++ b/src/services/aphp/callApi.ts
@@ -322,6 +322,7 @@ type fetchDocumentReferenceProps = {
   encounter?: string
   'encounter-identifier'?: string
   onlyPdfAvailable?: boolean
+  excludeImportedDocuments?: boolean
   'patient-identifier'?: string
   facet?: ('class' | 'visit-year-month-gender-facet')[]
   uniqueFacet?: 'subject'[]
@@ -363,6 +364,7 @@ export const fetchDocumentReference = async (
     patient,
     encounter,
     onlyPdfAvailable,
+    excludeImportedDocuments = true,
     minDate,
     maxDate,
     executiveUnits,
@@ -381,10 +383,13 @@ export const fetchDocumentReference = async (
   uniqueFacet = uniqueValues(uniqueFacet)
   _elements = uniqueValues(_elements)
 
-  // By default, all the calls to `/DocumentReference` will have `'type:not=https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor'` and patient.active=true in parameter
-  let options: string[] = [
-    `type:not=${encodeURIComponent('https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor')}`
-  ]
+  // By default, all the calls to `/DocumentReference` will exclude imported documents (`type:not=https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor`) and have patient.active=true in parameter.
+  let options: string[] = []
+  if (excludeImportedDocuments)
+    options = [
+      ...options,
+      `type:not=${encodeURIComponent('https://terminology.eds.aphp.fr/fhir/CodeSystem/aphp-document-class|doc-impor')}`
+    ]
 
   if (appConfig.core.fhir.totalCount) options = [...options, '_total=accurate']
   if (appConfig.core.fhir.filterActive) options = [...options, 'patient.active=true']

--- a/src/types/searchCriterias.ts
+++ b/src/types/searchCriterias.ts
@@ -249,6 +249,7 @@ export enum FilterKeys {
   END_DATE = 'endDate',
   DURATION_RANGE = 'durationRange',
   ONLY_PDF_AVAILABLE = 'onlyPdfAvailable',
+  EXCLUDE_IMPORTED_DOCUMENTS = 'excludeImportedDocuments',
   SOURCE = 'source',
   EXECUTIVE_UNITS = 'executiveUnits',
   DOC_TYPES = 'docTypes',
@@ -386,6 +387,7 @@ export type DocumentsFilters = GenericFilter & {
   docTypes: SimpleCodeType[]
   docStatuses: LabelObject[]
   onlyPdfAvailable: boolean
+  excludeImportedDocuments: boolean
 }
 
 export interface CohortsFilters {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -81,6 +81,9 @@ export const removeFilter = <F>(key: FilterKeys, value: FilterValue, filters: F)
       case FilterKeys.ONLY_PDF_AVAILABLE:
         castedFilters[key] = false
         break
+      case FilterKeys.EXCLUDE_IMPORTED_DOCUMENTS:
+        castedFilters[key] = false
+        break
     }
   }
   return { ...castedFilters }
@@ -128,7 +131,8 @@ export const getFilterLabel = (key: FilterKeys, value: FilterValue): string => {
     [FilterKeys.ENCOUNTER_STATUS]: (value) =>
       `Statut de la visite associée : ${capitalizeFirstLetter((value as LabelObject)?.label ?? '')}`,
     [FilterKeys.VALIDATED_STATUS]: () => `Analyses dont les résultats ont été validés`,
-    [FilterKeys.ONLY_PDF_AVAILABLE]: () => `Documents dont les PDF sont disponibles`
+    [FilterKeys.ONLY_PDF_AVAILABLE]: () => `Documents dont les PDF sont disponibles`,
+    [FilterKeys.EXCLUDE_IMPORTED_DOCUMENTS]: () => `Documents importés exclus`
   }
 
   const filterLabel = filterLabelMapper[key]
@@ -213,6 +217,13 @@ export const selectFiltersAsArray = (filters: Filters, searchInput: string | und
             value: value as FilterValue,
             label: getFilterLabel(key, value)
           })
+          break
+        case FilterKeys.EXCLUDE_IMPORTED_DOCUMENTS:
+          result.push({
+            category: key,
+            value: value as FilterValue,
+            label: getFilterLabel(key, value)
+          })
       }
     }
   }
@@ -238,6 +249,7 @@ export const atLeastOneSearchCriteria = (searchCriterias: SearchCriterias<Filter
     ('docTypes' in filters && filters.docTypes?.length > 0) ||
     ('docStatuses' in filters && filters.docStatuses?.length > 0) ||
     ('onlyPdfAvailable' in filters && !!filters.onlyPdfAvailable) ||
+    ('excludeImportedDocuments' in filters && !!filters.excludeImportedDocuments) ||
     ('formName' in filters && filters.formName.length > 0) ||
     ('administrationRoutes' in filters && filters.administrationRoutes && filters.administrationRoutes.length > 0) ||
     ('prescriptionTypes' in filters && filters.prescriptionTypes && filters.prescriptionTypes.length > 0) ||


### PR DESCRIPTION
## Objectif

fix: https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3311

Rendre visibles et modifiables des filtres implicites appliqués en dur sur les documents (DocumentReference), qui masquaient les 
documents importés sans que l'utilisateur en soit informé.

## Changements réalisés

Restitution : ajout d'une case « Exclure les documents importés » (visible, modifiable, cochée par défaut). Le filtre type:not=...|doc-impor, auparavant en dur dans fetchDocumentReference, est désormais piloté par ce filtre. Chip affiché + suppression via la croix + propagation au compteur d'export.

Requêteur : dans le critère Documents, le type:not=doc-impor du defaultFilter devient un switch « Exclure les documents importés » (activé par défaut) ;

## Impacts
Front : nouveau filtre UI (Restitution + Requêteur),

## Tests réalisés
Manuels.

## Risques

Pas de risques relevés
