### PR TITLE
chore: bump requeteur format version to v1.6.3 (3371)

### DIFF
--- a/src/utils/cohortCreation.ts
+++ b/src/utils/cohortCreation.ts
@@ -14,7 +14,7 @@
  * - Request joining for complex query composition
  *
  * @module cohortCreation
- * @version 1.6.2
+ * @version 1.6.3
  * @since 1.0.0
  */
 
@@ -47,7 +47,7 @@ import { getValueSetFromCodeSystem } from './valueSets'
 import { formatAge } from './age'
 
 /** Current version of the Requeteur format used for cohort requests */
-const REQUETEUR_VERSION = 'v1.6.2'
+const REQUETEUR_VERSION = 'v1.6.3'
 
 /** Default criteria group used as fallback when group lookup fails */
 const DEFAULT_GROUP_ERROR: CriteriaGroup = {


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/issues/3371

Complément front de la continuité des requêtes CCAM (back : aphp/Cohort360-Back-end#552). Le patch de migration back `v1.6.3` doit ne cibler que les anciennes requêtes.

## Changements réalisés
Bump `REQUETEUR_VERSION` `v1.6.2` → `v1.6.3` (les nouvelles requêtes sont tag à la version courante, donc exclues de la migration).

## Impacts
None

## Tests réalisés
N/C

## Risques
None

Blocked by aphp/Cohort360-Back-end#552