### PR TITLE
fix(request): wrong number version

### DIFF
--- a/src/__tests__/cohortCreation/saveJsonGuard.test.ts
+++ b/src/__tests__/cohortCreation/saveJsonGuard.test.ts
@@ -1,0 +1,156 @@
+import { configureStore, combineReducers } from '@reduxjs/toolkit'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// createSnapshot is the only path that POSTs /cohort/request-query-snapshots/.
+// We mock it so we can count how many times a snapshot creation is actually
+// requested for a given sequence of saveJson dispatches.
+const createSnapshot = vi.fn()
+
+vi.mock('services/aphp', () => ({
+  default: {
+    cohortCreation: {
+      createSnapshot: (...args: unknown[]) => createSnapshot(...args)
+    }
+  }
+}))
+
+import cohortCreation, {
+  saveJson,
+  resetCohortCreation,
+  fetchRequestCohortCreation
+} from 'state/cohortCreation'
+
+const makeStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      cohortCreation: combineReducers({
+        request: cohortCreation
+      })
+    }),
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware({ serializableCheck: false })
+  })
+
+const snapshotResponse = (uuid: string, version: number) => ({
+  uuid,
+  created_at: '2024-01-01T00:00:00Z',
+  cohorts_count: 0,
+  patients_count: 0,
+  version,
+  serialized_query: '{}',
+  dated_measures: []
+})
+
+const seedRequest = (store: ReturnType<typeof makeStore>, requestId: string) => {
+  // Give the request an id (and keep snapshotsHistory empty) so saveJson takes
+  // the createSnapshot branch.
+  store.dispatch({
+    type: fetchRequestCohortCreation.fulfilled.type,
+    payload: { requestId, snapshotsHistory: [] }
+  })
+}
+
+describe('saveJson duplicate-POST guard', () => {
+  beforeEach(() => {
+    createSnapshot.mockReset()
+  })
+
+  it('creates a single snapshot when the same save is dispatched twice concurrently', async () => {
+    const store = makeStore()
+    seedRequest(store, 'req-1')
+
+    let resolveSnapshot: (value: unknown) => void = () => {}
+    createSnapshot.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+
+    // Two dispatches in the same tick: the second must be blocked by the guard.
+    const first = store.dispatch(saveJson({ newJson: '{"a":1}' }))
+    const second = store.dispatch(saveJson({ newJson: '{"a":1}' }))
+
+    resolveSnapshot(snapshotResponse('snap-1', 1))
+    await Promise.all([first, second])
+
+    expect(createSnapshot).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not issue a second POST while the first save is still in flight', async () => {
+    const store = makeStore()
+    seedRequest(store, 'req-2')
+
+    let resolveSnapshot: (value: unknown) => void = () => {}
+    createSnapshot.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+
+    const first = store.dispatch(saveJson({ newJson: '{"b":1}' }))
+    // Dispatched in a later tick while the first POST has not resolved yet.
+    await Promise.resolve()
+    const second = store.dispatch(saveJson({ newJson: '{"b":1}' }))
+
+    resolveSnapshot(snapshotResponse('snap-2', 1))
+    await Promise.all([first, second])
+
+    expect(createSnapshot).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a subsequent save once the previous one has settled', async () => {
+    const store = makeStore()
+    seedRequest(store, 'req-3')
+
+    createSnapshot
+      .mockResolvedValueOnce(snapshotResponse('snap-3a', 1))
+      .mockResolvedValueOnce(snapshotResponse('snap-3b', 2))
+
+    await store.dispatch(saveJson({ newJson: '{"c":1}' }))
+    await store.dispatch(saveJson({ newJson: '{"c":2}' }))
+
+    expect(createSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases the guard after a failed save so the next save can run', async () => {
+    const store = makeStore()
+    seedRequest(store, 'req-4')
+
+    createSnapshot
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce(snapshotResponse('snap-4', 1))
+
+    await store.dispatch(saveJson({ newJson: '{"d":1}' }))
+    await store.dispatch(saveJson({ newJson: '{"d":2}' }))
+
+    // First rejected, guard released in finally, second succeeds.
+    expect(createSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases the guard even when resetCohortCreation clears saveLoading mid-flight', async () => {
+    const store = makeStore()
+    seedRequest(store, 'req-5')
+
+    let resolveSnapshot: (value: unknown) => void = () => {}
+    createSnapshot.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+
+    const first = store.dispatch(saveJson({ newJson: '{"e":1}' }))
+    // A reset (as happens on the open-request flow) puts saveLoading back to
+    // false while the first POST is still in flight; the module-scoped guard
+    // must still block the overlapping save.
+    store.dispatch(resetCohortCreation())
+    seedRequest(store, 'req-5')
+    const second = store.dispatch(saveJson({ newJson: '{"e":1}' }))
+
+    resolveSnapshot(snapshotResponse('snap-5', 1))
+    await Promise.all([first, second])
+
+    expect(createSnapshot).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__tests__/cohortCreation/saveJsonGuard.test.ts
+++ b/src/__tests__/cohortCreation/saveJsonGuard.test.ts
@@ -1,4 +1,4 @@
-import { configureStore, combineReducers } from '@reduxjs/toolkit'
+import { configureStore } from '@reduxjs/toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // createSnapshot is the only path that POSTs /cohort/request-query-snapshots/.
@@ -14,19 +14,18 @@ vi.mock('services/aphp', () => ({
   }
 }))
 
-import cohortCreation, {
+import { rootReducer } from 'state/store'
+import {
   saveJson,
   resetCohortCreation,
   fetchRequestCohortCreation
 } from 'state/cohortCreation'
 
+// Use the full rootReducer so the store's state matches the RootState type the
+// saveJson thunk is typed against (createAsyncThunk<..., { state: RootState }>).
 const makeStore = () =>
   configureStore({
-    reducer: combineReducers({
-      cohortCreation: combineReducers({
-        request: cohortCreation
-      })
-    }),
+    reducer: rootReducer,
     middleware: (getDefaultMiddleware) => getDefaultMiddleware({ serializableCheck: false })
   })
 

--- a/src/__tests__/routes/cohortCreationRoute.test.ts
+++ b/src/__tests__/routes/cohortCreationRoute.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { matchPath } from 'react-router'
+
+// The three former /cohort/new routes were merged into a single route with
+// optional params so navigating from /cohort/new to /cohort/new/:requestId no
+// longer remounts CohortCreation (which caused a duplicate snapshot POST).
+// We validate the matching behaviour of that consolidated pattern here without
+// importing the full route config (which pulls in heavy view dependencies).
+const COHORT_NEW_PATH = '/cohort/new/:requestId?/:snapshotId?'
+
+describe('consolidated /cohort/new route pattern', () => {
+  it('matches /cohort/new without params', () => {
+    const match = matchPath(COHORT_NEW_PATH, '/cohort/new')
+    expect(match).not.toBeNull()
+    expect(match?.params.requestId).toBeUndefined()
+    expect(match?.params.snapshotId).toBeUndefined()
+  })
+
+  it('matches /cohort/new/:requestId', () => {
+    const match = matchPath(COHORT_NEW_PATH, '/cohort/new/req-123')
+    expect(match).not.toBeNull()
+    expect(match?.params.requestId).toBe('req-123')
+    expect(match?.params.snapshotId).toBeUndefined()
+  })
+
+  it('matches /cohort/new/:requestId/:snapshotId', () => {
+    const match = matchPath(COHORT_NEW_PATH, '/cohort/new/req-123/snap-456')
+    expect(match).not.toBeNull()
+    expect(match?.params.requestId).toBe('req-123')
+    expect(match?.params.snapshotId).toBe('snap-456')
+  })
+})

--- a/src/components/Routes/AppNavigation/config.tsx
+++ b/src/components/Routes/AppNavigation/config.tsx
@@ -118,28 +118,18 @@ const configRoutes = (): ConfigRoute[] => {
     },
     /**
      * Cohort360: Cohorts Creation Page
+     *
+     * gestion-de-projet: a single route with optional params keeps CohortCreation
+     * (Requeteur/DiagramView) mounted when the app navigates from /cohort/new to
+     * /cohort/new/:requestId after the request is created. Separate routes remount
+     * the tree, which re-ran the auto-build effect and produced a second
+     * POST /request-query-snapshots/.
      */
     {
       exact: true,
       displaySideBar: true,
-      path: '/cohort/new',
+      path: '/cohort/new/:requestId?/:snapshotId?',
       name: 'cohort/new',
-      isPrivate: true,
-      element: <CohortCreation />
-    },
-    {
-      exact: true,
-      displaySideBar: true,
-      path: '/cohort/new/:requestId',
-      name: 'cohort/new/:requestId',
-      isPrivate: true,
-      element: <CohortCreation />
-    },
-    {
-      exact: true,
-      displaySideBar: true,
-      path: '/cohort/new/:requestId/:snapshotId',
-      name: 'cohort/new/:requestId/:snapshotId',
       isPrivate: true,
       element: <CohortCreation />
     },

--- a/src/state/cohortCreation.ts
+++ b/src/state/cohortCreation.ts
@@ -31,6 +31,16 @@ import { ScopeElement } from 'types/scope'
 const isThunkConditionAbort = (e: unknown): boolean =>
   typeof e === 'object' && e !== null && (e as { name?: unknown }).name === 'ConditionError'
 
+// gestion-de-projet: module-scoped guard for saveJson. The Redux `saveLoading`
+// flag alone does not stop every duplicate POST /request-query-snapshots/,
+// because two buildCohortCreation dispatches can each start a saveJson in
+// separate async ticks where the first has already settled (saveLoading back to
+// false) yet the second still creates another snapshot. This latch is claimed
+// synchronously in saveJson's `condition` and released in the thunk body's
+// `finally`, so a second overlapping save is aborted rather than issuing a
+// second POST.
+let saveJsonInFlight = false
+
 /**
  * State interface for cohort creation functionality.
  * Contains all data needed for building and managing cohort requests.
@@ -346,12 +356,25 @@ const saveJson = createAsyncThunk<SaveJsonReturn, SaveJsonParams, { state: RootS
     } catch (error) {
       console.error(error)
       throw error
+    } finally {
+      // Release the latch so subsequent (distinct) saves can run.
+      saveJsonInFlight = false
     }
   },
   {
     // gestion-de-projet#3259: concurrent saveJson dispatches race and both POST
     // as firstTime=true, producing snapshots with duplicate version numbers.
-    condition: (_, { getState }) => !getState().cohortCreation.request.saveLoading
+    // saveLoading is not enough on its own (two dispatches in separate ticks can
+    // both observe it false), so we also claim saveJsonInFlight synchronously here
+    // and release it in the thunk body's finally.
+    // Note: no caller aborts saveJson, so the payload creator (and its finally)
+    // always runs once this returns true. If an abort-before-body path is ever
+    // introduced, the latch would also need a reset on that path.
+    condition: (_, { getState }) => {
+      if (saveJsonInFlight || getState().cohortCreation.request.saveLoading) return false
+      saveJsonInFlight = true
+      return true
+    }
   }
 )
 


### PR DESCRIPTION
## Objectif

Fix : https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3259

Corriger le double appel intermittent à POST /api/back/cohort/request-query-snapshots/ lors de la création/ouverture d'une requête dans le module de création de cohorte. Un snapshot était créé en double (parfois avec des versions dupliquées), générant des appels réseau et des snapshots superflus.

## Changements réalisés

Deux corrections complémentaires, ciblant deux causes distinctes du même symptôme :

1. Sérialisation de saveJson (cause racine du double POST) — src/state/cohortCreation.ts

- Ajout d'un verrou saveJsonInFlight au niveau module, posé synchroniquement dans la condition du thunk saveJson et libéré dans le finally du corps du thunk.

- Le garde d'origine ne s'appuyait que sur saveLoading (état Redux). Ce flag est insuffisant car deux buildCohortCreation peuvent déclencher deux saveJson dans des ticks asynchrones distincts, et un resetCohortCreation() (appelé sur le flux d'ouverture) réinitialise saveLoading=false via defaultInitialState() pendant qu'un POST est encore en vol — rouvrant ainsi la garde.

- Le verrou saveJsonInFlight vit hors du store Redux, donc il n'est pas affecté par resetCohortCreation et reste actif pendant toute la durée du save. Un second saveJson chevauchant est alors abandonné (ConditionError, déjà géré) au lieu d'émettre un second POST. Comme createSnapshot (le POST) n'est appelé que depuis saveJson, tous les chemins de création de snapshot sont couverts.

2. Consolidation des routes de création (cause du remontage déterministe) — src/components/Routes/AppNavigation/config.tsx

- Fusion des trois routes '/cohort/new', '/cohort/new/:requestId' et '/cohort/new/:requestId/:snapshotId' (qui rendaient toutes <CohortCreation />) en une seule route avec paramètres optionnels : '/cohort/new/:requestId?/:snapshotId?'.

- Motivation : après création d'une requête, Requeteur fait navigate('/cohort/new/${requestId}'). Avec des <Route> séparés, ce changement d'URL faisait démonter/remonter l'arbre CohortCreation/Requeteur/DiagramView, ce qui ré-exécutait l'effet d'auto-build (buildCohortCreation) et relançait un POST. Une route unique conserve l'instance montée et supprime ce remontage.

## Impacts
Front : logique de garde du thunk saveJson et configuration de routing du module de création de cohorte. Aucun changement d'UI.

## Tests réalisés

- Manuel : création d'une nouvelle requête et ouverture d'une requête existante, vérification dans l'onglet réseau qu'un seul POST /cohort/request-query-snapshots/ est émis (répété plusieurs fois pour couvrir le caractère intermittent).

- Phase d'init des TNR (qui crée plusieurs requête)

- Nouveau test unitaire

## Risques

Point de vigilance : la disparition du remontage modifie le cycle de vie de DiagramView sur la transition « création → URL alignée ». Le comportement d'initialisation (auto-build, bloc population) a été validé manuellement, mais reste le principal point à surveiller en recette.
