### PR TITLE
fix(cohortCreation): prefix-search stored CCAM codes in builder expand (3371)

### DIFF
--- a/src/services/aphp/serviceValueSets.ts
+++ b/src/services/aphp/serviceValueSets.ts
@@ -228,6 +228,12 @@ const getChildrenFromCodesBatch = async (
   codes: string[],
   signal?: AbortSignal
 ): Promise<Back_API_Response<Hierarchy<FhirItem>>> => {
+  // Le référentiel CCAM a été ré-encodé (chapitres suffixés par des points, feuilles par `_001`) :
+  // un code enregistré avant ce ré-encodage ne matche plus à l'identique et se cherche en préfixe.
+  // Chapitres (6 chiffres) et feuilles (4 lettres + 3 chiffres) s'incrémentant par unité, le
+  // wildcard ne déborde pas sur un code voisin. Scopé au valueset CCAM, idempotent sur `*`.
+  const isCcamHierarchy = valueSetUrl === getConfig().features.procedure?.valueSets?.procedureHierarchy?.url
+  const toFilterValue = (code: string) => (isCcamHierarchy && code && !code.endsWith('*') ? `${code}*` : code)
   const json = {
     resourceType: 'Parameters',
     parameter: [
@@ -245,7 +251,7 @@ const getChildrenFromCodesBatch = async (
               {
                 filter: codes.map((code) => ({
                   op: 'is-a',
-                  value: code
+                  value: toFilterValue(code)
                 }))
               }
             ]


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3371

Volet affichage, hors périmètre écrit de l'issue ("affichage des nouveaux codes dans l'arborescence du requêteur, à traiter séparément"). Dans le créateur de requête, les codes CCAM d'une requête existante (stockés avant ré-encodage) ne se résolvaient plus : les appels `ValueSet/$expand` (op `is-a`), faits en **direct front → FHIR** sans passer par le back, renvoyaient vide/404.

## Changements réalisés
Le code envoyé au filtre `is-a` du `$expand` est cherché en préfixe (`code*`), scopé au valueset CCAM (`procedure.valueSets.procedureHierarchy`). Idempotent sur `*`, sans effet sur les autres référentiels (CIM10, ATC…).

## Impacts
Front, résolution et affichage des critères CCAM dans le builder.

## Tests réalisés
TU + Lint

## Risques
Vérifier à l'écran que l'arbre CCAM s'ouvre toujours normalement.
