### PR TITLE
fix(cohortCreation): resolve re-encoded CCAM codes in builder chips (3371)

### DIFF
--- a/src/__tests__/utilsFunction/valueSets.test.ts
+++ b/src/__tests__/utilsFunction/valueSets.test.ts
@@ -11,7 +11,8 @@ import {
   getResourceTypeFromUrl,
   getCodeSystemUrlFromValueSetUrl,
   getSearchSystemUrl,
-  checkIsLeaf
+  checkIsLeaf,
+  matchStoredCodeInCache
 } from 'utils/valueSets'
 import { HIERARCHY_ROOT } from 'services/aphp/serviceValueSets'
 import { Hierarchy } from 'types/hierarchy'
@@ -58,7 +59,7 @@ vi.mock('data/valueSets', () => ({
       label: 'Test ValueSet',
       title: 'Test ValueSet Title',
       standard: true,
-      checked: false,
+      checked: false,
       joinDisplayWithCode: true,
       joinDisplayWithSystem: true,
       codeSystemUrls: ['https://terminology.hl7.org/CodeSystem/test-codesystem']
@@ -68,7 +69,7 @@ vi.mock('data/valueSets', () => ({
       label: 'Another ValueSet',
       title: 'Another ValueSet Title',
       standard: false,
-      checked: false,
+      checked: false,
       joinDisplayWithCode: false,
       joinDisplayWithSystem: false,
       codeSystemUrls: ['https://terminology.hl7.org/CodeSystem/another-codesystem']
@@ -78,7 +79,7 @@ vi.mock('data/valueSets', () => ({
       label: 'Biology Anabio',
       title: 'Biology Anabio Title',
       standard: true,
-      checked: false,
+      checked: false,
       joinDisplayWithCode: true,
       joinDisplayWithSystem: false,
       codeSystemUrls: ['https://terminology.hl7.org/CodeSystem/biology-anabio']
@@ -618,6 +619,39 @@ describe('valueSets utilities', () => {
       expect(getSearchSystemUrl(config)).toBe('https://terminology.hl7.org/CodeSystem/empty-codesystem')
       expect(errorSpy).toHaveBeenCalledOnce()
       errorSpy.mockRestore()
+    })
+  })
+
+  describe('matchStoredCodeInCache', () => {
+    const CCAM = 'https://ccam'
+    const item = (id: string, label: string, system = CCAM): Hierarchy<FhirItem> =>
+      ({ id, label, system }) as Hierarchy<FhirItem>
+    const cache = {
+      [CCAM]: [item('001472.....', 'Noeud 001472'), item('001472.001', 'Enfant 001472'), item('JQGA004....1', 'Acte JQGA004')]
+    }
+
+    it('returns the exact match when the stored code still exists', () => {
+      const cacheExact = { [CCAM]: [item('001472', 'Exact 001472'), item('001472.....', 'Noeud')] }
+      const stored = { id: '001472', label: '', system: CCAM }
+      expect((matchStoredCodeInCache(stored, cacheExact, true) as Hierarchy<FhirItem>).label).toBe('Exact 001472')
+    })
+
+    it('prefers the padding node over a descendant for a re-encoded CCAM code', () => {
+      // Le noeud `001472.....` (suffixe tout en points) doit gagner sur son enfant `001472.001`.
+      const stored = { id: '001472', label: '', system: CCAM }
+      expect((matchStoredCodeInCache(stored, cache, true) as Hierarchy<FhirItem>).label).toBe('Noeud 001472')
+    })
+
+    it('does not prefix-match when disabled (avoids CIM10 E11 -> E110)', () => {
+      const cim = 'https://cim10'
+      const cimCache = { [cim]: [item('E110', 'Diabète compliqué', cim)] }
+      const stored = { id: 'E11', system: cim }
+      expect(matchStoredCodeInCache(stored, cimCache, false)).toBe(stored)
+    })
+
+    it('returns the stored code untouched when nothing matches', () => {
+      const stored = { id: 'ZZZZ999', system: CCAM }
+      expect(matchStoredCodeInCache(stored, cache, true)).toBe(stored)
     })
   })
 })

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/renderers.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/renderers.tsx
@@ -27,7 +27,8 @@ import { CriteriaLabel } from 'components/ui/CriteriaLabel'
 import { Comparators } from 'types/requestCriterias'
 import SimpleSelect from 'components/ui/Inputs/SimpleSelect'
 import ValueSetField from 'components/SearchValueSet/ValueSetField'
-import { checkIsLeaf } from 'utils/valueSets'
+import { checkIsLeaf, matchStoredCodeInCache } from 'utils/valueSets'
+import { getConfig } from 'config'
 import { selectValueSetCodes } from 'state/valueSets'
 import SearchbarWithCheck from 'components/ui/Searchbar/SearchbarWithChecks'
 import { SearchbarWithCheckWrapper } from 'components/ui/Searchbar/styles'
@@ -324,13 +325,11 @@ const FORM_ITEM_RENDERER: { [key in CriteriaFormItemType]: CriteriaFormItemView<
         props.definition.valueSetsInfo.map((ref) => ref.url)
       )
     )
-    const valueWithLabels = (props.value ?? []).map(
-      (code) =>
-        (code.system && codeCaches[code.system]?.find((c) => c.id === code.id)) ||
-        Object.keys(codeCaches)
-          .flatMap((key) => codeCaches[key])
-          .find((c) => c.id === code.id) ||
-        code
+    const ccamHierarchyUrl = getConfig().features.procedure.valueSets.procedureHierarchy?.url
+    const allowPrefixMatch =
+      !!ccamHierarchyUrl && props.definition.valueSetsInfo.some((ref) => ref.url === ccamHierarchyUrl)
+    const valueWithLabels = (props.value ?? []).map((code) =>
+      matchStoredCodeInCache(code, codeCaches, allowPrefixMatch)
     )
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [valueBuffer, setValueBuffer] = useState(valueWithLabels)

--- a/src/utils/cohortCreation.ts
+++ b/src/utils/cohortCreation.ts
@@ -773,8 +773,10 @@ const getCodesForValueSet = async (
   for (const valueSetUrl of valueSetUrls) {
     try {
       return (await getChildrenFromCodes(valueSetUrl, [code])).results
-    } catch {
-      console.error("Ce n'est pas une erreur.")
+    } catch (error) {
+      // Le code n'est pas résolu dans ce valueSet : on tente le suivant. Si tous échouent,
+      // getCodesForValueSet renvoie undefined et l'appelant loggue le code non trouvé.
+      console.warn(`Résolution du code ${code} dans le valueSet ${valueSetUrl} échouée, essai suivant`, error)
     }
   }
 }

--- a/src/utils/valueSets.ts
+++ b/src/utils/valueSets.ts
@@ -21,6 +21,31 @@ export const getValueSetFromCodeSystem = (codeSystemUrl: string): string | undef
   return reference?.url
 }
 
+// Associe un code stocké au concept du cache : match exact d'abord. Pour le CCAM
+// (allowPrefixMatch), les codes ré-encodés (ex. `001472` -> `001472.....`) sont retrouvés par
+// préfixe. Le préfixe reste désactivé hors CCAM pour ne pas confondre des voisins (CIM10 `E11`/`E110`).
+export const matchStoredCodeInCache = <T extends { id: string; system?: string }>(
+  code: T,
+  codeCaches: Record<string, Hierarchy<FhirItem>[]>,
+  allowPrefixMatch: boolean
+): Hierarchy<FhirItem> | T => {
+  const allCodes = Object.values(codeCaches).flat()
+  const exact =
+    (code.system ? codeCaches[code.system]?.find((c) => c.id === code.id) : undefined) ??
+    allCodes.find((c) => c.id === code.id)
+  if (exact) return exact
+  if (allowPrefixMatch && code.id) {
+    const scope = (code.system ? codeCaches[code.system] : undefined) ?? allCodes
+    const prefixMatches = scope.filter((c) => typeof c.id === 'string' && c.id.startsWith(code.id))
+    // Le noeud ré-encodé garde un suffixe de padding (uniquement des points, ex. `001472.....`) ;
+    // ses descendants portent des chiffres (`001472.001`). On préfère le noeud, sinon le plus court.
+    const node = prefixMatches.find((c) => /^\.*$/.test(c.id.slice(code.id.length)))
+    const best = node ?? [...prefixMatches].sort((a, b) => a.id.length - b.id.length)[0]
+    if (best) return best
+  }
+  return code
+}
+
 // Helper function to get ValueSet Reference from CodeSystem URL
 export const getValueSetReferenceFromCodeSystem = (codeSystemUrl: string) => {
   const references = getReferences(getConfig())


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3371

Volet **affichage** du requêteur (hors périmètre écrit de 3371, "à traiter séparément"), suite de #1278. Après le ré-encodage CCAM, les codes stockés avant ré-encodage (ex. `001472`) ne s'affichaient plus dans les chips d'un critère : le label se résout par **id exact** contre le cache, or le `$expand` ne renvoie que le code ré-encodé (`001472.....`), jamais l'ancien.

## Changements réalisés
- Résolution **tolérante au préfixe** (`matchStoredCodeInCache`) : match exact d'abord, sinon on associe le code stocké au nœud ré-encodé par préfixe (nœud à padding de points préféré à un descendant). Scopé au valueset CCAM pour ne pas confondre des codes voisins (CIM10 `E11`/`E110`).
- Log honnête à la place du `catch { console.error("Ce n'est pas une erreur.") }` qui masquait les vraies erreurs (dont des 404).

## Impacts
Front, résolution/affichage des critères CCAM dans le créateur de requête. Iso pour les autres référentiels.

## Tests réalisés
Unitaires `matchStoredCodeInCache` (match exact, préfixe nœud vs descendant, non-CCAM intact, aucun match). eslint + tsc + vitest verts. Validé contre la réponse réelle du `$expand` qualif : `is-a 001472*` renvoie bien le nœud `001472.....` ("Évacuation de collection de la peau et des tissus mous"), que le match préfixe cible.

## Risques

