### PR TITLE
fix(cohortCreation): fix CCAM count + diagram chip for re-encoded codes (3371)

### DIFF
--- a/src/__tests__/mappers/chipDisplayMapper.test.ts
+++ b/src/__tests__/mappers/chipDisplayMapper.test.ts
@@ -12,12 +12,15 @@ const item = { valueSetsInfo: [{ url: CCAM }] } as any
 
 describe('CHIPS_DISPLAY_METHODS.codeSearch', () => {
   it('builds a chip when the stored code resolves in cache', () => {
-    const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: '000742', system: CCAM }], item, valueSets, ['', false])
+    const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: '000742', system: CCAM }] as any, item, valueSets, ['', false])
     expect(chip).toBeTruthy()
   })
 
   it('does not throw when the code is absent from cache', () => {
-    const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: 'ZZZ999', system: 'https://other' }], item, valueSets, ['', false])
+    const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: 'ZZZ999', system: 'https://other' }] as any, item, valueSets, [
+      '',
+      false
+    ])
     expect(chip).toBeTruthy()
   })
 })

--- a/src/__tests__/mappers/chipDisplayMapper.test.ts
+++ b/src/__tests__/mappers/chipDisplayMapper.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { CHIPS_DISPLAY_METHODS } from 'components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper'
+
+const CCAM = 'https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP'
+
+const valueSets = {
+  entities: {},
+  cache: { [CCAM]: [{ id: '000742.....', label: 'Fermeture de fistule', system: CCAM }] }
+} as any
+
+const item = { valueSetsInfo: [{ url: CCAM }] } as any
+
+describe('CHIPS_DISPLAY_METHODS.codeSearch', () => {
+  it('builds a chip when the stored code resolves in cache', () => {
+    const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: '000742', system: CCAM }], item, valueSets, ['', false])
+    expect(chip).toBeTruthy()
+  })
+
+  it('does not throw when the code is absent from cache', () => {
+    const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: 'ZZZ999', system: 'https://other' }], item, valueSets, ['', false])
+    expect(chip).toBeTruthy()
+  })
+})

--- a/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
+++ b/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const criteriaMocks = vi.hoisted(() => ({ getAllCriteriaItems: vi.fn() }))
+const valueSetMocks = vi.hoisted(() => ({
+  getValueSetFromCodeSystem: vi.fn(),
+  matchStoredCodeInCache: vi.fn()
+}))
+
+vi.mock('components/CreationCohort/DataList_Criteria', () => criteriaMocks)
+vi.mock('utils/valueSets', () => valueSetMocks)
+vi.mock('services/aphp/serviceValueSets', () => ({ getChildrenFromCodes: vi.fn(), HIERARCHY_ROOT: '__ROOT__' }))
+
+import { healCriteriaCodes } from 'utils/cohortCreation'
+
+const ccamDefinition = {
+  id: 'PROC',
+  formDefinition: {
+    itemSections: [{ items: [{ type: 'codeSearch', valueKey: 'code', valueSetsInfo: [{ url: 'https://ccam-vs' }] }] }]
+  }
+}
+
+describe('healCriteriaCodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    criteriaMocks.getAllCriteriaItems.mockReturnValue([ccamDefinition])
+    valueSetMocks.matchStoredCodeInCache.mockImplementation((code: any) =>
+      code.id === '000742' ? { id: '000742.....', system: 'https://ccam-vs', label: 'noeud' } : code
+    )
+  })
+
+  it('rewrites a re-encoded CCAM code and returns a new criteria array', () => {
+    const selectedCriteria = [{ type: 'PROC', code: [{ id: '000742', system: 'https://atih' }] }] as any
+
+    const healed = healCriteriaCodes([] as any, selectedCriteria, {} as any)
+
+    expect(healed).not.toBe(selectedCriteria)
+    expect(healed[0].code[0].id).toBe('000742.....')
+    expect(healed[0].code[0].system).toBe('https://ccam-vs')
+  })
+
+  it('returns the same reference when nothing changes (idempotent)', () => {
+    const selectedCriteria = [{ type: 'PROC', code: [{ id: '000742.....', system: 'https://ccam-vs' }] }] as any
+
+    expect(healCriteriaCodes([] as any, selectedCriteria, {} as any)).toBe(selectedCriteria)
+  })
+
+  it('leaves criteria without a matching definition untouched', () => {
+    const selectedCriteria = [{ type: 'UNKNOWN', code: [{ id: '000742', system: 'https://atih' }] }] as any
+
+    expect(healCriteriaCodes([] as any, selectedCriteria, {} as any)).toBe(selectedCriteria)
+  })
+
+  it('skips codeSearch fields with no selected value', () => {
+    const selectedCriteria = [{ type: 'PROC', code: [] }] as any
+
+    expect(healCriteriaCodes([] as any, selectedCriteria, {} as any)).toBe(selectedCriteria)
+  })
+})

--- a/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
+++ b/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
@@ -31,7 +31,7 @@ describe('healCriteriaCodes', () => {
   it('rewrites a re-encoded CCAM code and returns a new criteria array', () => {
     const selectedCriteria = [{ type: 'PROC', code: [{ id: '000742', system: 'https://atih' }] }] as any
 
-    const healed = healCriteriaCodes([] as any, selectedCriteria, {} as any)
+    const healed = healCriteriaCodes([] as any, selectedCriteria, {} as any) as any[]
 
     expect(healed).not.toBe(selectedCriteria)
     expect(healed[0].code[0].id).toBe('000742.....')

--- a/src/__tests__/utilsFunction/valueSets.test.ts
+++ b/src/__tests__/utilsFunction/valueSets.test.ts
@@ -12,7 +12,8 @@ import {
   getCodeSystemUrlFromValueSetUrl,
   getSearchSystemUrl,
   checkIsLeaf,
-  matchStoredCodeInCache
+  matchStoredCodeInCache,
+  findCodeByIdOrPrefix
 } from 'utils/valueSets'
 import { HIERARCHY_ROOT } from 'services/aphp/serviceValueSets'
 import { Hierarchy } from 'types/hierarchy'
@@ -652,6 +653,38 @@ describe('valueSets utilities', () => {
     it('returns the stored code untouched when nothing matches', () => {
       const stored = { id: 'ZZZZ999', system: CCAM }
       expect(matchStoredCodeInCache(stored, cache, true)).toBe(stored)
+    })
+  })
+
+  describe('findCodeByIdOrPrefix', () => {
+    const item = (id: string): Hierarchy<FhirItem> => ({ id, label: id, system: 'https://ccam' }) as Hierarchy<FhirItem>
+
+    it('returns the exact match first', () => {
+      const list = [item('001472'), item('001472.....')]
+      expect(findCodeByIdOrPrefix(list, '001472', true)?.id).toBe('001472')
+    })
+
+    it('returns undefined when no exact match and prefix is disabled', () => {
+      expect(findCodeByIdOrPrefix([item('001472.....')], '001472', false)).toBeUndefined()
+    })
+
+    it('returns undefined for an empty id', () => {
+      expect(findCodeByIdOrPrefix([item('001472.....')], '', true)).toBeUndefined()
+    })
+
+    it('prefers the padding node over a descendant', () => {
+      const list = [item('001472.001'), item('001472.....'), item('001472.0012')]
+      expect(findCodeByIdOrPrefix(list, '001472', true)?.id).toBe('001472.....')
+    })
+
+    it('falls back to the shortest prefix match when there is no padding node', () => {
+      const list = [item('EPFA001...12'), item('EPFA001...1')]
+      expect(findCodeByIdOrPrefix(list, 'EPFA001', true)?.id).toBe('EPFA001...1')
+    })
+
+    it('ignores undefined entries in the list', () => {
+      const list = [undefined, item('001472.....')]
+      expect(findCodeByIdOrPrefix(list, '001472', true)?.id).toBe('001472.....')
     })
   })
 })

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper.tsx
@@ -24,7 +24,7 @@ import allDocTypes from 'assets/docTypes.json'
 import moment from 'moment'
 import { getDurationRangeLabel } from 'utils/age'
 import { getConfig } from 'config'
-import { getValueSetFromCodeSystem } from 'utils/valueSets'
+import { getValueSetFromCodeSystem, findCodeByIdOrPrefix } from 'utils/valueSets'
 
 /************************************************************************************/
 /*                        Criteria Form Item Chip Display                           */
@@ -143,6 +143,8 @@ const getLabelsForCodeSearchItem = (
   item: CodeSearchItem,
   valueSets: ValueSetStore
 ): LabelObject[] => {
+  const ccamHierarchyUrl = getConfig().features.procedure.valueSets.procedureHierarchy?.url
+  const allowPrefixMatch = !!ccamHierarchyUrl && item.valueSetsInfo.some((ref) => ref.url === ccamHierarchyUrl)
   return val
     .map((value) => {
       let cacheKey: string | undefined
@@ -158,11 +160,10 @@ const getLabelsForCodeSearchItem = (
         }
       }
 
-      return (
-        (cacheKey
-          ? valueSets.cache[cacheKey]
-          : item.valueSetsInfo.flatMap((valueset) => valueSets.cache[valueset.url])) || []
-      ).find((code) => code?.id === value.id) as LabelObject
+      const codeList = cacheKey
+        ? valueSets.cache[cacheKey]
+        : item.valueSetsInfo.flatMap((valueset) => valueSets.cache[valueset.url])
+      return findCodeByIdOrPrefix(codeList || [], value.id, allowPrefixMatch) as LabelObject
     })
     .filter((code) => code !== undefined)
 }

--- a/src/components/CreationCohort/Requeteur.tsx
+++ b/src/components/CreationCohort/Requeteur.tsx
@@ -9,7 +9,12 @@ import DiagramView from './DiagramView'
 import ModalCreateNewRequest from './Modals/ModalCreateNewRequest/ModalCreateNewRequest'
 
 import { useAppDispatch, useAppSelector } from 'state'
-import { editAllCriteria, fetchRequestCohortCreation, resetCohortCreation } from 'state/cohortCreation'
+import {
+  buildCohortCreation,
+  editAllCriteria,
+  fetchRequestCohortCreation,
+  resetCohortCreation
+} from 'state/cohortCreation'
 import { setSelectedRequest } from 'state/request'
 
 import { CurrentSnapshot } from 'types'
@@ -96,6 +101,7 @@ const Requeteur = () => {
       const healedCriteria = healCriteriaCodes(criteriaList(), selectedCriteria, criteriaCodesCache)
       if (healedCriteria !== selectedCriteria) {
         dispatch(editAllCriteria(healedCriteria))
+        dispatch(buildCohortCreation({ selectedPopulation: null }))
       }
 
       const allowMaternityForms = selectedPopulation?.every((population) => population?.access === 'Nominatif')

--- a/src/components/CreationCohort/Requeteur.tsx
+++ b/src/components/CreationCohort/Requeteur.tsx
@@ -9,14 +9,14 @@ import DiagramView from './DiagramView'
 import ModalCreateNewRequest from './Modals/ModalCreateNewRequest/ModalCreateNewRequest'
 
 import { useAppDispatch, useAppSelector } from 'state'
-import { fetchRequestCohortCreation, resetCohortCreation } from 'state/cohortCreation'
+import { editAllCriteria, fetchRequestCohortCreation, resetCohortCreation } from 'state/cohortCreation'
 import { setSelectedRequest } from 'state/request'
 
 import { CurrentSnapshot } from 'types'
 
 import criteriaList from './DataList_Criteria'
 
-import { cleanNominativeCriterias, fetchCriteriasCodes } from 'utils/cohortCreation'
+import { cleanNominativeCriterias, fetchCriteriasCodes, healCriteriaCodes } from 'utils/cohortCreation'
 
 import useStyles from './styles'
 import services from 'services/aphp'
@@ -92,6 +92,11 @@ const Requeteur = () => {
     try {
       const criteriaCodesCache = await fetchCriteriasCodes(criteriaList(), selectedCriteria, valueSets.cache)
       dispatch(updateCache(criteriaCodesCache))
+
+      const healedCriteria = healCriteriaCodes(criteriaList(), selectedCriteria, criteriaCodesCache)
+      if (healedCriteria !== selectedCriteria) {
+        dispatch(editAllCriteria(healedCriteria))
+      }
 
       const allowMaternityForms = selectedPopulation?.every((population) => population?.access === 'Nominatif')
       const questionnairesEnabled = config.features.questionnaires.enabled

--- a/src/services/aphp/serviceValueSets.ts
+++ b/src/services/aphp/serviceValueSets.ts
@@ -228,10 +228,7 @@ const getChildrenFromCodesBatch = async (
   codes: string[],
   signal?: AbortSignal
 ): Promise<Back_API_Response<Hierarchy<FhirItem>>> => {
-  // Le référentiel CCAM a été ré-encodé (chapitres suffixés par des points, feuilles par `_001`) :
-  // un code enregistré avant ce ré-encodage ne matche plus à l'identique et se cherche en préfixe.
-  // Chapitres (6 chiffres) et feuilles (4 lettres + 3 chiffres) s'incrémentant par unité, le
-  // wildcard ne déborde pas sur un code voisin. Scopé au valueset CCAM, idempotent sur `*`.
+  // Codes CCAM ré-encodés : un code d'avant ré-encodage se cherche en préfixe. Scopé au valueset CCAM.
   const isCcamHierarchy = valueSetUrl === getConfig().features.procedure?.valueSets?.procedureHierarchy?.url
   const toFilterValue = (code: string) => (isCcamHierarchy && code && !code.endsWith('*') ? `${code}*` : code)
   const json = {

--- a/src/utils/cohortCreation.ts
+++ b/src/utils/cohortCreation.ts
@@ -43,8 +43,9 @@ import { getChildrenFromCodes, HIERARCHY_ROOT } from 'services/aphp/serviceValue
 import { createHierarchyRoot } from './hierarchy'
 import { FhirItem } from 'types/valueSet'
 import { ScopeElement } from 'types/scope'
-import { getValueSetFromCodeSystem } from './valueSets'
+import { getValueSetFromCodeSystem, matchStoredCodeInCache } from './valueSets'
 import { formatAge } from './age'
+import { getConfig } from 'config'
 
 /** Current version of the Requeteur format used for cohort requests */
 const REQUETEUR_VERSION = 'v1.6.3'
@@ -774,9 +775,7 @@ const getCodesForValueSet = async (
     try {
       return (await getChildrenFromCodes(valueSetUrl, [code])).results
     } catch (error) {
-      // Le code n'est pas résolu dans ce valueSet : on tente le suivant. Si tous échouent,
-      // getCodesForValueSet renvoie undefined et l'appelant loggue le code non trouvé.
-      console.warn(`Résolution du code ${code} dans le valueSet ${valueSetUrl} échouée, essai suivant`, error)
+      console.warn(`Résolution du code ${code} dans le valueSet ${valueSetUrl} échouée`, error)
     }
   }
 }
@@ -852,6 +851,48 @@ export const fetchCriteriasCodes = async (
     }
   }
   return updatedCriteriaData
+}
+
+// Réaligne les codes CCAM d'avant ré-encodage sur leur forme courante du cache (000742 -> 000742.....).
+// Renvoie la référence d'origine si aucun code ne change.
+export const healCriteriaCodes = (
+  criteriaList: readonly CriteriaItemType[],
+  selectedCriteria: SelectedCriteriaType[],
+  cache: CodeCache
+): SelectedCriteriaType[] => {
+  const ccamHierarchyUrl = getConfig().features.procedure.valueSets.procedureHierarchy?.url
+  const allCriterias = getAllCriteriaItems(criteriaList)
+  let changed = false
+  const healed = selectedCriteria.map((criterion) => {
+    const definition = allCriterias.find((crit) => crit.id === criterion.type || crit.types?.includes(criterion.type))
+    const sections = definition?.formDefinition?.itemSections
+    if (!sections) return criterion
+    let next = criterion
+    for (const section of sections) {
+      for (const item of section.items || []) {
+        if (item.type !== 'codeSearch') continue
+        const dataKey = item.valueKey as keyof SelectedCriteriaType
+        const values = next[dataKey] as unknown as LabelObject[] | undefined
+        if (!values?.length) continue
+        const allowPrefixMatch = !!ccamHierarchyUrl && item.valueSetsInfo.some((ref) => ref.url === ccamHierarchyUrl)
+        let fieldChanged = false
+        const healedValues = values.map((code) => {
+          const match = matchStoredCodeInCache(code, cache, allowPrefixMatch) as LabelObject
+          if (match.id !== code.id || match.system !== code.system) {
+            fieldChanged = true
+            return match
+          }
+          return code
+        })
+        if (fieldChanged) {
+          changed = true
+          next = { ...next, [dataKey]: healedValues }
+        }
+      }
+    }
+    return next
+  })
+  return changed ? healed : selectedCriteria
 }
 
 /**

--- a/src/utils/valueSets.ts
+++ b/src/utils/valueSets.ts
@@ -21,10 +21,8 @@ export const getValueSetFromCodeSystem = (codeSystemUrl: string): string | undef
   return reference?.url
 }
 
-// Trouve un code dans une liste plate : match exact, sinon (CCAM, allowPrefixMatch) match par
-// préfixe. Les codes CCAM ré-encodés gardent un suffixe de padding (que des points, ex. `001472.....`),
-// leurs descendants portent des chiffres (`001472.001`) : on préfère le noeud, sinon le plus court.
-// Hors CCAM le préfixe reste off pour ne pas confondre des voisins (CIM10 `E11`/`E110`).
+// Match exact, sinon (CCAM) par préfixe : le noeud ré-encodé a un suffixe tout en points (`001472.....`),
+// préféré à ses descendants (`001472.001`). Désactivé hors CCAM pour éviter CIM10 `E11`/`E110`.
 export const findCodeByIdOrPrefix = (
   codes: readonly (Hierarchy<FhirItem> | undefined)[],
   id: string,

--- a/src/utils/valueSets.ts
+++ b/src/utils/valueSets.ts
@@ -21,29 +21,33 @@ export const getValueSetFromCodeSystem = (codeSystemUrl: string): string | undef
   return reference?.url
 }
 
-// Associe un code stocké au concept du cache : match exact d'abord. Pour le CCAM
-// (allowPrefixMatch), les codes ré-encodés (ex. `001472` -> `001472.....`) sont retrouvés par
-// préfixe. Le préfixe reste désactivé hors CCAM pour ne pas confondre des voisins (CIM10 `E11`/`E110`).
+// Trouve un code dans une liste plate : match exact, sinon (CCAM, allowPrefixMatch) match par
+// préfixe. Les codes CCAM ré-encodés gardent un suffixe de padding (que des points, ex. `001472.....`),
+// leurs descendants portent des chiffres (`001472.001`) : on préfère le noeud, sinon le plus court.
+// Hors CCAM le préfixe reste off pour ne pas confondre des voisins (CIM10 `E11`/`E110`).
+export const findCodeByIdOrPrefix = (
+  codes: readonly (Hierarchy<FhirItem> | undefined)[],
+  id: string,
+  allowPrefixMatch: boolean
+): Hierarchy<FhirItem> | undefined => {
+  const exact = codes.find((c) => c?.id === id)
+  if (exact || !allowPrefixMatch || !id) return exact
+  const prefixMatches = codes.filter((c): c is Hierarchy<FhirItem> => typeof c?.id === 'string' && c.id.startsWith(id))
+  return (
+    prefixMatches.find((c) => /^\.*$/.test(c.id.slice(id.length))) ??
+    [...prefixMatches].sort((a, b) => a.id.length - b.id.length)[0]
+  )
+}
+
+// Associe un code stocké au concept du cache (exact puis préfixe CCAM), sinon renvoie le code tel quel.
 export const matchStoredCodeInCache = <T extends { id: string; system?: string }>(
   code: T,
   codeCaches: Record<string, Hierarchy<FhirItem>[]>,
   allowPrefixMatch: boolean
 ): Hierarchy<FhirItem> | T => {
   const allCodes = Object.values(codeCaches).flat()
-  const exact =
-    (code.system ? codeCaches[code.system]?.find((c) => c.id === code.id) : undefined) ??
-    allCodes.find((c) => c.id === code.id)
-  if (exact) return exact
-  if (allowPrefixMatch && code.id) {
-    const scope = (code.system ? codeCaches[code.system] : undefined) ?? allCodes
-    const prefixMatches = scope.filter((c) => typeof c.id === 'string' && c.id.startsWith(code.id))
-    // Le noeud ré-encodé garde un suffixe de padding (uniquement des points, ex. `001472.....`) ;
-    // ses descendants portent des chiffres (`001472.001`). On préfère le noeud, sinon le plus court.
-    const node = prefixMatches.find((c) => /^\.*$/.test(c.id.slice(code.id.length)))
-    const best = node ?? [...prefixMatches].sort((a, b) => a.id.length - b.id.length)[0]
-    if (best) return best
-  }
-  return code
+  const scope = (code.system ? codeCaches[code.system] : undefined) ?? allCodes
+  return findCodeByIdOrPrefix(scope, code.id, allowPrefixMatch) ?? allCodes.find((c) => c.id === code.id) ?? code
 }
 
 // Helper function to get ValueSet Reference from CodeSystem URL


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3371

Suite de #1279 (qui n'a mergé que la résolution du form d'édition). Il restait deux volets non mergés :
- le **count** des requêtes à codes CCAM d'avant ré-encodage renvoyait 0 (les codes-nœuds numériques ne matchent pas en préfixe, cf. FQ Solr) ;
- le **chip de la carte diagramme** restait vide (résolution par id exact, comme le form d'édition avant #1279).

## Changements réalisés
- `healCriteriaCodes` (appelé au chargement dans `Requeteur`) réaligne les codes CCAM stockés sur leur forme ré-encodée courante via le cache `$expand` (`000742` → `000742.....`, système `CCAMDescriptiveVerAPHP`). Le count et l'affichage sont alors corrects sans rouvrir chaque critère.
- `chipDisplayMapper` (carte diagramme) utilise la même résolution que le form d'édition, via un helper partagé `findCodeByIdOrPrefix` (match exact puis préfixe scopé CCAM).

## Impacts
Front, requêteur : résolution/affichage des critères CCAM + codes envoyés au count. Iso pour les autres référentiels (préfixe scopé CCAM).

## Tests réalisés
eslint + tsc clean. Unitaires `findCodeByIdOrPrefix`/`matchStoredCodeInCache`. Validé sur qualif : une requête à codes CCAM d'avant ré-encodage remonte le bon count (identique au self-heal manuel) et les chips s'affichent (form + diagramme).

## Risques
Réalignement côté front (pas d'expansion hiérarchique back). Les codes réalignés persistent à la sauvegarde/au count (nouvelle version) ; le count stocké périmé reste affiché jusqu'au recalcul.
