### PR TITLE
ci: allow frontend frigo Docker publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - develop
+      - frontend-frigo
       - 'release/**'
 
 jobs:
@@ -50,6 +51,9 @@ jobs:
               ;;
             develop)
               echo "IMAGE_TAGS=${DOCKER_REPO}:develop" >> "$GITHUB_ENV"
+              ;;
+            frontend-frigo)
+              echo "IMAGE_TAGS=${DOCKER_REPO}:frontend-frigo" >> "$GITHUB_ENV"
               ;;
             release/*)
               echo "IMAGE_TAGS=${DOCKER_REPO}:${VERSION}-rc,${DOCKER_REPO}:${VERSION}-rc.${SHORT_SHA}" >> "$GITHUB_ENV"


### PR DESCRIPTION
﻿## Objet

Autoriser la publication Docker depuis la branche `frontend-frigo`.

## Changements

- Ajoute `frontend-frigo` au filtre `workflow_run.branches` du workflow `publish.yml`.
- Ajoute le tag Docker `aphpid/cohort360-frontend:frontend-frigo` pour cette branche.

## Contexte

Le workflow `workflow_run` doit être présent sur la branche par défaut pour se déclencher. Cette PR porte donc la règle sur `develop` afin que les runs de test `frontend-frigo` puissent déclencher le publish.
