### PR TITLE
fix(cohortCreation): résout l'import circulaire au chargement du store

### DIFF
--- a/src/__tests__/utilsFunction/cohortCreation.fetchCriteriasCodes.test.ts
+++ b/src/__tests__/utilsFunction/cohortCreation.fetchCriteriasCodes.test.ts
@@ -6,16 +6,11 @@ const servicesMocks = vi.hoisted(() => ({
   HIERARCHY_ROOT: '__HIERARCHY_ROOT__'
 }))
 
-const criteriaMocks = vi.hoisted(() => ({
-  getAllCriteriaItems: vi.fn()
-}))
-
 const valueSetMocks = vi.hoisted(() => ({
   getValueSetFromCodeSystem: vi.fn()
 }))
 
 vi.mock('services/aphp/serviceValueSets', () => servicesMocks)
-vi.mock('components/CreationCohort/DataList_Criteria', () => criteriaMocks)
 vi.mock('utils/valueSets', () => valueSetMocks)
 
 import { fetchCriteriasCodes } from 'utils/cohortCreation'
@@ -29,28 +24,29 @@ const mkCode = (id: string, valueSetUrl: string): Hierarchy<any> => ({
   inferior_levels_ids: ''
 })
 
-describe('fetchCriteriasCodes real module coverage', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-
-    criteriaMocks.getAllCriteriaItems.mockReturnValue([
-      {
-        id: 'TYPE_A',
-        formDefinition: {
-          itemSections: [
+// Criteria definitions passed directly and flattened via getAllCriteriaItems.
+const criteriaList = [
+  {
+    id: 'TYPE_A',
+    formDefinition: {
+      itemSections: [
+        {
+          items: [
             {
-              items: [
-                {
-                  type: 'codeSearch',
-                  valueKey: 'codesA',
-                  valueSetsInfo: [{ url: 'https://default-valueset' }]
-                }
-              ]
+              type: 'codeSearch',
+              valueKey: 'codesA',
+              valueSetsInfo: [{ url: 'https://default-valueset' }]
             }
           ]
         }
-      }
-    ])
+      ]
+    }
+  }
+] as any
+
+describe('fetchCriteriasCodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
 
     valueSetMocks.getValueSetFromCodeSystem.mockImplementation((system: string) => {
       if (system === 'https://system-mapped') return 'https://mapped-valueset'
@@ -70,7 +66,7 @@ describe('fetchCriteriasCodes real module coverage', () => {
       }
     ] as any
 
-    const cache = await fetchCriteriasCodes([] as any, selectedCriteria)
+    const cache = await fetchCriteriasCodes(criteriaList, selectedCriteria)
 
     expect(cache['https://mapped-valueset']).toBeDefined()
     expect(cache['https://mapped-valueset'][0].id).toBe('A1')
@@ -84,7 +80,7 @@ describe('fetchCriteriasCodes real module coverage', () => {
       }
     ] as any
 
-    const cache = await fetchCriteriasCodes([] as any, selectedCriteria)
+    const cache = await fetchCriteriasCodes(criteriaList, selectedCriteria)
 
     expect(cache['https://default-valueset']).toBeDefined()
     expect(cache['https://default-valueset'][0].id).toBe('A2')
@@ -102,7 +98,7 @@ describe('fetchCriteriasCodes real module coverage', () => {
       'https://default-valueset': [mkCode('A3', 'https://default-valueset')]
     }
 
-    const cache = await fetchCriteriasCodes([] as any, selectedCriteria, oldCache as any)
+    const cache = await fetchCriteriasCodes(criteriaList, selectedCriteria, oldCache as any)
 
     expect(servicesMocks.getChildrenFromCodes).not.toHaveBeenCalledWith('https://default-valueset', ['A3'])
     expect(cache['https://default-valueset']).toHaveLength(1)
@@ -116,7 +112,7 @@ describe('fetchCriteriasCodes real module coverage', () => {
       }
     ] as any
 
-    const cache = await fetchCriteriasCodes([] as any, selectedCriteria)
+    const cache = await fetchCriteriasCodes(criteriaList, selectedCriteria)
 
     expect(servicesMocks.getChildrenFromCodes).not.toHaveBeenCalled()
     expect(cache['https://mapped-valueset'][0].id).toBe('__HIERARCHY_ROOT__')

--- a/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
+++ b/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
@@ -1,12 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const criteriaMocks = vi.hoisted(() => ({ getAllCriteriaItems: vi.fn() }))
 const valueSetMocks = vi.hoisted(() => ({
   getValueSetFromCodeSystem: vi.fn(),
   matchStoredCodeInCache: vi.fn()
 }))
 
-vi.mock('components/CreationCohort/DataList_Criteria', () => criteriaMocks)
 vi.mock('utils/valueSets', () => valueSetMocks)
 vi.mock('services/aphp/serviceValueSets', () => ({ getChildrenFromCodes: vi.fn(), HIERARCHY_ROOT: '__ROOT__' }))
 
@@ -19,10 +17,12 @@ const ccamDefinition = {
   }
 }
 
+// Criteria definitions passed directly and flattened via getAllCriteriaItems.
+const criteriaList = [ccamDefinition] as any
+
 describe('healCriteriaCodes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    criteriaMocks.getAllCriteriaItems.mockReturnValue([ccamDefinition])
     valueSetMocks.matchStoredCodeInCache.mockImplementation((code: any) =>
       code.id === '000742' ? { id: '000742.....', system: 'https://ccam-vs', label: 'noeud' } : code
     )
@@ -31,7 +31,7 @@ describe('healCriteriaCodes', () => {
   it('rewrites a re-encoded CCAM code and returns a new criteria array', () => {
     const selectedCriteria = [{ type: 'PROC', code: [{ id: '000742', system: 'https://atih' }] }] as any
 
-    const healed = healCriteriaCodes([] as any, selectedCriteria, {} as any) as any[]
+    const healed = healCriteriaCodes(criteriaList, selectedCriteria, {} as any) as any[]
 
     expect(healed).not.toBe(selectedCriteria)
     expect(healed[0].code[0].id).toBe('000742.....')
@@ -41,18 +41,18 @@ describe('healCriteriaCodes', () => {
   it('returns the same reference when nothing changes (idempotent)', () => {
     const selectedCriteria = [{ type: 'PROC', code: [{ id: '000742.....', system: 'https://ccam-vs' }] }] as any
 
-    expect(healCriteriaCodes([] as any, selectedCriteria, {} as any)).toBe(selectedCriteria)
+    expect(healCriteriaCodes(criteriaList, selectedCriteria, {} as any)).toBe(selectedCriteria)
   })
 
   it('leaves criteria without a matching definition untouched', () => {
     const selectedCriteria = [{ type: 'UNKNOWN', code: [{ id: '000742', system: 'https://atih' }] }] as any
 
-    expect(healCriteriaCodes([] as any, selectedCriteria, {} as any)).toBe(selectedCriteria)
+    expect(healCriteriaCodes(criteriaList, selectedCriteria, {} as any)).toBe(selectedCriteria)
   })
 
   it('skips codeSearch fields with no selected value', () => {
     const selectedCriteria = [{ type: 'PROC', code: [] }] as any
 
-    expect(healCriteriaCodes([] as any, selectedCriteria, {} as any)).toBe(selectedCriteria)
+    expect(healCriteriaCodes(criteriaList, selectedCriteria, {} as any)).toBe(selectedCriteria)
   })
 })

--- a/src/components/CreationCohort/DataList_Criteria.tsx
+++ b/src/components/CreationCohort/DataList_Criteria.tsx
@@ -193,15 +193,6 @@ const criteriaList: () => CriteriaItemType[] = () => {
   ]
 }
 
-export const getAllCriteriaItems = (criteria: readonly CriteriaItemType[]): CriteriaItemType[] => {
-  const allCriteriaItems: CriteriaItemType[] = []
-  for (const criterion of criteria) {
-    allCriteriaItems.push(criterion)
-    if (criterion.subItems && criterion.subItems.length > 0) {
-      allCriteriaItems.push(...getAllCriteriaItems(criterion.subItems))
-    }
-  }
-  return allCriteriaItems
-}
+export { getAllCriteriaItems } from 'utils/cohortCreation'
 
 export default criteriaList

--- a/src/utils/cohortCreation.ts
+++ b/src/utils/cohortCreation.ts
@@ -39,7 +39,6 @@ import { Hierarchy } from 'types/hierarchy'
 import { CodeCache } from 'state/valueSets'
 import { NewDurationRangeType } from 'components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/types'
 import { getChildrenFromCodes, HIERARCHY_ROOT } from 'services/aphp/serviceValueSets'
-import { getAllCriteriaItems } from 'components/CreationCohort/DataList_Criteria'
 import { createHierarchyRoot } from './hierarchy'
 import { FhirItem } from 'types/valueSet'
 import { ScopeElement } from 'types/scope'
@@ -58,8 +57,19 @@ const DEFAULT_GROUP_ERROR: CriteriaGroup = {
   criteriaIds: []
 }
 
+export const getAllCriteriaItems = (criteria: readonly CriteriaItemType[]): CriteriaItemType[] => {
+  const allCriteriaItems: CriteriaItemType[] = []
+  for (const criterion of criteria) {
+    allCriteriaItems.push(criterion)
+    if (criterion.subItems && criterion.subItems.length > 0) {
+      allCriteriaItems.push(...getAllCriteriaItems(criterion.subItems))
+    }
+  }
+  return allCriteriaItems
+}
+
 const getCriteriaDefinitions = async (): Promise<CriteriaItemType[]> => {
-  const { default: criteriaList, getAllCriteriaItems } = await import('components/CreationCohort/DataList_Criteria')
+  const { default: criteriaList } = await import('components/CreationCohort/DataList_Criteria')
   return getAllCriteriaItems(criteriaList())
 }
 
@@ -819,7 +829,6 @@ export const fetchCriteriasCodes = async (
   oldCriteriaCache?: CodeCache
 ): Promise<CodeCache> => {
   const updatedCriteriaData: CodeCache = { ...oldCriteriaCache }
-  const { getAllCriteriaItems } = await import('components/CreationCohort/DataList_Criteria')
   const allCriterias = getAllCriteriaItems(criteriaList)
   for (const criteria of allCriterias) {
     const criteriaValues = selectedCriteria.filter(


### PR DESCRIPTION
## Objectif
Corriger l'erreur runtime au démarrage `store.ts:31 Uncaught ReferenceError: Cannot access 'cohortCreation' before initialization` — un temporal dead zone provoqué par une dépendance circulaire.

Le commit `92d003db` a introduit un import **statique** de `getAllCriteriaItems` depuis le module composant `DataList_Criteria.tsx` dans `utils/cohortCreation.ts`. Cet import tire tout l'arbre de composants criteria (`RequestForm` → `state`) dans le chemin d'initialisation du store, fermant le cycle :

```
store.ts → state/cohortCreation → utils/cohortCreation → DataList_Criteria
        → RequestForm → 'state' → state/store
```

## Changements réalisés
`getAllCriteriaItems` est une fonction pure et sans dépendances (elle aplatit un arbre de critères).

- Déplacée dans `utils/cohortCreation.ts`.
- Ré-exportée depuis `DataList_Criteria.tsx` pour les consommateurs existants (`CriteriaCard`, `state/valueSets`, tests) — aucun changement d'import ailleurs.
- Les sites qui utilisaient `await import(...)` pour ce helper s'en passent désormais.

Le chemin d'initialisation du store ne charge plus l'arbre composant : le cycle est cassé à la racine.

## Impacts
Aucun (a part que le front refonctionne)

## Tests réalisés
Unitaires

## Risques
- Faible. Le point de vigilance est de **ne pas réintroduire d'import statique** de `DataList_Criteria` (ou de tout module tirant `state`) dans le chemin d'initialisation du store, sous peine de recréer le cycle.
- Le re-export dans `DataList_Criteria.tsx` doit être conservée tant que des consommateurs importent `getAllCriteriaItems` depuis ce module.