### PR TITLE
fix(onboarding): aligne l'étape 2 sur les maquettes

### DIFF
--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -1,3 +1,4 @@
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { Avatar, Box, Button, Typography } from '@mui/material'
 import logo from 'assets/images/logo-login.png'
@@ -50,7 +51,13 @@ const OnboardingLayout = () => {
   const footer = (
     <>
       {screen === 'steps' && (
-        <Button onClick={goBack} disabled={saving}>
+        <Button
+          className={classes.backButton}
+          variant="outlined"
+          onClick={goBack}
+          disabled={saving}
+          startIcon={<ArrowBackIcon />}
+        >
           Revenir
         </Button>
       )}

--- a/src/views/Onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/Onboarding/__tests__/Onboarding.test.tsx
@@ -60,7 +60,7 @@ describe('Onboarding page', () => {
     expect(screen.getByTestId('onboarding-warning')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /Continuer/ }))
-    expect(screen.getByText("L'enregistrement de vos actions")).toBeInTheDocument()
+    expect(screen.getByText("Les finalités d'usage")).toBeInTheDocument()
     expect(screen.queryByTestId('onboarding-warning')).not.toBeInTheDocument()
   })
 

--- a/src/views/Onboarding/__tests__/steps.test.ts
+++ b/src/views/Onboarding/__tests__/steps.test.ts
@@ -14,12 +14,12 @@ describe('onboarding step 2 configuration', () => {
   it('exposes the seven informative screens then the charter and its confirmation', () => {
     expect(commitmentScreens().map((screen) => screen.key)).toEqual([
       'usage-rules',
-      'actions-logging',
-      'care-team-sharing',
-      'data-crossing',
-      'minimal-data-use',
       'usage-purposes',
+      'minimal-data-use',
+      'data-crossing',
       'data-deletion',
+      'care-team-sharing',
+      'actions-logging',
       'charter-signature',
       'charter-confirmation'
     ])

--- a/src/views/Onboarding/screens/commitments/CharterSignature.tsx
+++ b/src/views/Onboarding/screens/commitments/CharterSignature.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 
 import useStyles from '../../styles'
 
-// Served from `public/` so the document can be swapped without rebuilding the app.
-export const CHARTER_PDF_URL = '/documents/charte-engagement-cohort360.pdf'
+const CHARTER_PDF_URL = '/documents/charte-engagement-cohort360.pdf'
+const CHARTER_PDF_EMBED_URL = `${CHARTER_PDF_URL}#navpanes=0&toolbar=0&statusbar=0&view=FitH`
 
 const CharterSignature = () => {
   const { classes } = useStyles()
@@ -17,7 +17,7 @@ const CharterSignature = () => {
       <Box className={classes.documentViewer}>
         <object
           className={classes.documentFrame}
-          data={CHARTER_PDF_URL}
+          data={CHARTER_PDF_EMBED_URL}
           type="application/pdf"
           aria-label="Charte d'engagement Cohort360"
         >

--- a/src/views/Onboarding/screens/commitments/__tests__/CharterSignature.test.tsx
+++ b/src/views/Onboarding/screens/commitments/__tests__/CharterSignature.test.tsx
@@ -2,13 +2,15 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 
-import CharterSignature, { CHARTER_PDF_URL } from '../CharterSignature'
+import CharterSignature from '../CharterSignature'
+
+const CHARTER_PDF_URL = '/documents/charte-engagement-cohort360.pdf'
 
 describe('CharterSignature (RG3309.01)', () => {
   it('embeds the charter as a scrollable PDF document', () => {
     render(<CharterSignature />)
     const document = screen.getByLabelText("Charte d'engagement Cohort360")
-    expect(document).toHaveAttribute('data', CHARTER_PDF_URL)
+    expect(document).toHaveAttribute('data', `${CHARTER_PDF_URL}#navpanes=0&toolbar=0&statusbar=0&view=FitH`)
     expect(document).toHaveAttribute('type', 'application/pdf')
   })
 

--- a/src/views/Onboarding/steps.ts
+++ b/src/views/Onboarding/steps.ts
@@ -67,12 +67,12 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
     icon: HistoryEduIcon,
     screens: [
       { key: 'usage-rules', component: UsageRules },
-      { key: 'actions-logging', component: ActionsLogging },
-      { key: 'care-team-sharing', component: CareTeamSharing },
-      { key: 'data-crossing', component: DataCrossing },
-      { key: 'minimal-data-use', component: MinimalDataUse },
       { key: 'usage-purposes', component: UsagePurposes },
+      { key: 'minimal-data-use', component: MinimalDataUse },
+      { key: 'data-crossing', component: DataCrossing },
       { key: 'data-deletion', component: DataDeletion },
+      { key: 'care-team-sharing', component: CareTeamSharing },
+      { key: 'actions-logging', component: ActionsLogging },
       {
         key: 'charter-signature',
         component: CharterSignature,

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -141,6 +141,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
     gap: theme.spacing(2),
     marginTop: theme.spacing(3)
   },
+  backButton: {
+    // Pushed to the opposite edge from the primary action, which stays right-aligned when alone.
+    marginRight: 'auto',
+    backgroundColor: T.surface,
+    '&:hover': {
+      backgroundColor: T.surface
+    }
+  },
   title: {
     color: T.ink,
     fontWeight: 700


### PR DESCRIPTION
## Objectif

Corriger les écarts avec les maquettes remontés sur l'étape 2 du parcours d'onboarding

Fixes [gestion-de-projet#3308](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3308)

## Changements réalisés

- Ordre des écrans
- PDF Charte affichée sans la barre d'outils ni le panneau latéral du lecteur
- Bouton `Revenir` ancré à gauche du footer, face à l'action primaire, et doté de sa flèche

## Impacts

Front

## Tests réalisés

Unitaires

## Risques

Le rendu du lecteur PDF dépend du navigateur : les paramètres passés au `#fragment` masquent la barre d'outils sur Chrome et Edge, mais Firefox les ignore et continue de l'afficher