### PR TITLE
fix(export): loading progress download#3350

### DIFF
--- a/src/views/DownloadPopup/DownloadPopup.tsx
+++ b/src/views/DownloadPopup/DownloadPopup.tsx
@@ -40,10 +40,7 @@ const DownloadPopup: React.FC = () => {
         path = `/cohort/${resource}/${itemId}/download/`
       }
       const downloadResponse = await apiBackend.get(path, {
-        responseType: 'blob',
-        onDownloadProgress: (progressEvent) => {
-          if (progressEvent.progress === 1) setDownloading(null)
-        }
+        responseType: 'blob'
       })
 
       if (downloadResponse.status !== 200) {
@@ -65,6 +62,8 @@ const DownloadPopup: React.FC = () => {
 
       document.body.removeChild(link)
       window.URL.revokeObjectURL(url)
+
+      setDownloading(null)
     } catch (error) {
       console.error(error)
       setDownloading(false)
@@ -89,7 +88,7 @@ const DownloadPopup: React.FC = () => {
   if (downloading === null) {
     downloadStatusContent = (
       <Typography variant="h2" color="primary">
-        Téléchargement terminé!
+        Téléchargement terminé !
       </Typography>
     )
   } else if (downloading) {


### PR DESCRIPTION
## Objectif

Fix : https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3350

Lorsqu'un utilisateur clique sur le lien de téléchargement reçu par mail une fois son export prêt, Cohort360 s'ouvre sur la popup de téléchargement et affiche un spinner qui ne s'arrête jamais. Le fichier est pourtant bien téléchargé sur le poste. Ce comportement laisse croire que le téléchargement est en cours ou a échoué, et génère des contacts récurrents au support.

## Changements réalisés

Suppression du callback onDownloadProgress qui n'arrêtait le spinner que lorsque progressEvent.progress === 1. Cette valeur est undefined quand la réponse (blob/zip) est servie sans en-tête Content-Length donc la condition n'était jamais vraie et l'état downloading restait bloqué à true.

Ajout de setDownloading(null) après la fin effective du téléchargement de sorte que l'état « terminé » est atteint sur tout chemin de succès, indépendamment de la présence de Content-Length.

## Impacts
Front

## Tests réalisés
Manuel : ouverture du lien de téléchargement

## Risques
Faible. Le changement est isolé à un seul composant et ne modifie pas la logique métier
