### PR TITLE
feat(onboarding): palette EDS et alignement UI sur les maquettes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -8,21 +8,33 @@
     <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&family=Open+Sans:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&family=Open+Sans:wght@400;600;700&family=Rubik:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-    <link rel="stylesheet" href="/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+    <link
+      rel="stylesheet"
+      href="/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
     <script type="text/javascript">
-      var undefinedClarityAppId = "{" + "VITE_CLARITY_APP_ID" + "}"
-      var clarityAppId = "{VITE_CLARITY_APP_ID}"
-      if (clarityAppId !== "" && clarityAppId !== undefinedClarityAppId) {
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", clarityAppId);
+      var undefinedClarityAppId = '{' + 'VITE_CLARITY_APP_ID' + '}'
+      var clarityAppId = '{VITE_CLARITY_APP_ID}'
+      if (clarityAppId !== '' && clarityAppId !== undefinedClarityAppId) {
+        ;(function (c, l, a, r, i, t, y) {
+          c[a] =
+            c[a] ||
+            function () {
+              ;(c[a].q = c[a].q || []).push(arguments)
+            }
+          t = l.createElement(r)
+          t.async = 1
+          t.src = 'https://www.clarity.ms/tag/' + i
+          y = l.getElementsByTagName(r)[0]
+          y.parentNode.insertBefore(t, y)
+        })(window, document, 'clarity', 'script', clarityAppId)
       }
     </script>
     <!--
@@ -44,7 +56,7 @@
       #root:not(:empty) + #app-loader {
         display: none;
       }
-      
+
       #app-loader {
         position: fixed;
         top: 0;
@@ -65,7 +77,7 @@
         border-radius: 50%;
         width: 96px;
         height: 96px;
-        color: #ED6D91;
+        color: #ed6d91;
       }
       .loader:before,
       .loader:after {
@@ -81,9 +93,9 @@
         animation: 1s spin linear infinite;
       }
       .loader:after {
-        color: #0063AF;
+        color: #0063af;
         transform: rotateY(70deg);
-        animation-delay: .4s;
+        animation-delay: 0.4s;
       }
 
       @keyframes rotate {
@@ -107,44 +119,42 @@
       @keyframes spin {
         0%,
         100% {
-          box-shadow: .2em 0px 0 0px currentcolor;
+          box-shadow: 0.2em 0px 0 0px currentcolor;
         }
         12% {
-          box-shadow: .2em .2em 0 0 currentcolor;
+          box-shadow: 0.2em 0.2em 0 0 currentcolor;
         }
         25% {
-          box-shadow: 0 .2em 0 0px currentcolor;
+          box-shadow: 0 0.2em 0 0px currentcolor;
         }
         37% {
-          box-shadow: -.2em .2em 0 0 currentcolor;
+          box-shadow: -0.2em 0.2em 0 0 currentcolor;
         }
         50% {
-          box-shadow: -.2em 0 0 0 currentcolor;
+          box-shadow: -0.2em 0 0 0 currentcolor;
         }
         62% {
-          box-shadow: -.2em -.2em 0 0 currentcolor;
+          box-shadow: -0.2em -0.2em 0 0 currentcolor;
         }
         75% {
-          box-shadow: 0px -.2em 0 0 currentcolor;
+          box-shadow: 0px -0.2em 0 0 currentcolor;
         }
         87% {
-          box-shadow: .2em -.2em 0 0 currentcolor;
+          box-shadow: 0.2em -0.2em 0 0 currentcolor;
         }
       }
-    
     </style>
   </head>
 
   <body style="margin: 0px">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    
+
     <div id="app-loader">
-      <div style="margin-bottom: 3em; margin-top: -10%;">
+      <div style="margin-bottom: 3em; margin-top: -10%">
         <img src="/logo_c360_small.png" alt="Cohort360" />
       </div>
-      <div class="loader">
-      </div>
+      <div class="loader"></div>
     </div>
     <!--
       This HTML file is a template.

--- a/src/components/ui/InfoBadge/index.tsx
+++ b/src/components/ui/InfoBadge/index.tsx
@@ -1,11 +1,13 @@
 import { styled, useTheme } from '@mui/material'
 import React from 'react'
 
-import CircleBadge from 'components/ui/CircleBadge'
+import CircleBadge, { type CircleBadgeVariant } from 'components/ui/CircleBadge'
 
 type InfoBadgeProps = {
   size?: number
   className?: string
+  color?: string
+  variant?: CircleBadgeVariant
 }
 
 const Glyph = styled('span')({
@@ -13,11 +15,11 @@ const Glyph = styled('span')({
   fontStyle: 'italic'
 })
 
-const InfoBadge = ({ size = 24, className }: InfoBadgeProps) => {
+const InfoBadge = ({ size = 24, className, color, variant = 'outlined' }: InfoBadgeProps) => {
   const theme = useTheme()
 
   return (
-    <CircleBadge color={theme.palette.primary.dark} variant="outlined" size={size} className={className}>
+    <CircleBadge color={color ?? theme.palette.primary.dark} variant={variant} size={size} className={className}>
       <Glyph>i</Glyph>
     </CircleBadge>
   )

--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -62,7 +62,13 @@ const OnboardingLayout = () => {
           Revenir
         </Button>
       )}
-      <Button variant="contained" onClick={goNext} disabled={saving} endIcon={<ArrowForwardIcon />}>
+      <Button
+        className={classes.nextButton}
+        variant="contained"
+        onClick={goNext}
+        disabled={saving}
+        endIcon={<ArrowForwardIcon />}
+      >
         {primaryLabel}
       </Button>
     </>

--- a/src/views/Onboarding/__tests__/steps.test.ts
+++ b/src/views/Onboarding/__tests__/steps.test.ts
@@ -32,8 +32,8 @@ describe('onboarding step 2 configuration', () => {
     expect(withAction[0].primaryAction?.label).toBe('Signer')
   })
 
-  it('renders the charter without the card wrapper', () => {
-    expect(getScreenConfig(COMMITMENTS_STEP, 7)?.layout).toBe('bare')
+  it('renders the charter inside the default card wrapper', () => {
+    expect(getScreenConfig(COMMITMENTS_STEP, 7)?.layout).toBeUndefined()
   })
 
   it('counts a screenless step as a single slot so the journey never stalls', () => {

--- a/src/views/Onboarding/screens/commitments/CharterSignature.tsx
+++ b/src/views/Onboarding/screens/commitments/CharterSignature.tsx
@@ -11,7 +11,7 @@ const CharterSignature = () => {
 
   return (
     <Box>
-      <Typography variant="h3" className={classes.bareTitle}>
+      <Typography variant="h4" className={classes.title}>
         Signer la charte d'engagement
       </Typography>
       <Box className={classes.documentViewer}>
@@ -28,6 +28,11 @@ const CharterSignature = () => {
             </Link>
           </Box>
         </object>
+      </Box>
+      <Box className={classes.linkRow}>
+        <Link className={classes.link} href={CHARTER_PDF_URL} download>
+          Télécharger une copie de la charte d'engagement
+        </Link>
       </Box>
     </Box>
   )

--- a/src/views/Onboarding/screens/commitments/UsagePurposes.tsx
+++ b/src/views/Onboarding/screens/commitments/UsagePurposes.tsx
@@ -30,7 +30,7 @@ const UsagePurposes = () => {
       <Typography className={classes.sectionText}>
         L'Entrepôt de Données de Santé (EDS) de l'AP-HP contient des données à caractère personnel sensibles.
       </Typography>
-      <Typography className={classes.subTitle}>
+      <Typography className={classes.sectionLead}>
         Seules certaines finalités d'utilisation des données sont autorisées :
       </Typography>
       {PURPOSES.map(({ label, icon: Icon }) => (
@@ -38,7 +38,7 @@ const UsagePurposes = () => {
           <Box className={classes.iconBox}>
             <Icon fontSize="small" />
           </Box>
-          <Typography className={classes.stepTitle}>{label}</Typography>
+          <Typography className={classes.rowLabel}>{label}</Typography>
         </Box>
       ))}
     </Box>

--- a/src/views/Onboarding/screens/environment/WhatIsEds.tsx
+++ b/src/views/Onboarding/screens/environment/WhatIsEds.tsx
@@ -9,6 +9,7 @@ import type { SvgIconProps } from '@mui/material'
 import InfoBadge from 'components/ui/InfoBadge'
 import type { ComponentType } from 'react'
 import React from 'react'
+import { eds } from 'styles/palette'
 
 import useStyles from '../../styles'
 
@@ -83,7 +84,7 @@ const WhatIsEds = () => {
 
       <Divider className={classes.divider} />
       <Box className={classes.infoRow}>
-        <InfoBadge className={classes.infoBadge} />
+        <InfoBadge className={classes.infoBadge} variant="filled" color={eds.blue[600]} />
         <Typography className={classes.infoText}>
           Selon votre profil d'habilitation, vous accédez à des données nominatives (identité des patients visible) ou
           pseudonymisées (identité masquée).

--- a/src/views/Onboarding/steps.ts
+++ b/src/views/Onboarding/steps.ts
@@ -82,7 +82,6 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
       {
         key: 'charter-signature',
         component: CharterSignature,
-        layout: 'bare',
         primaryAction: {
           label: 'Signer',
           run: ({ signCharter }) => signCharter(),

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -1,14 +1,21 @@
 import type { Theme } from '@mui/material/styles'
+import { eds } from 'styles/palette'
 import { makeStyles } from 'tss-react/mui'
 
 import { onboardingTokens as T } from './tokens'
+
+const FONT = "'Rubik', sans-serif"
 
 const useStyles = makeStyles()((theme: Theme) => ({
   page: {
     minHeight: '100vh',
     display: 'flex',
     flexDirection: 'column',
-    backgroundColor: T.pageBg
+    backgroundColor: T.pageBg,
+    fontFamily: FONT,
+    '& .MuiTypography-root, & .MuiButton-root': {
+      fontFamily: FONT
+    }
   },
   header: {
     display: 'flex',
@@ -93,7 +100,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
     width: 28,
     height: 28,
     borderRadius: '50%',
-    border: `2px solid ${T.railTodo}`,
     backgroundColor: T.surface,
     color: T.railDone,
     display: 'flex',
@@ -103,12 +109,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
     fontWeight: 700
   },
   stepCircleActive: {
-    border: 'none',
     backgroundColor: T.railDone,
     color: T.surface
   },
   stepCircleCompleted: {
-    border: 'none',
     color: T.railDone
   },
   stepLabel: {
@@ -143,9 +147,19 @@ const useStyles = makeStyles()((theme: Theme) => ({
   backButton: {
     // Pushed to the opposite edge from the primary action, which stays right-aligned when alone.
     marginRight: 'auto',
+    color: eds.blue[400],
+    borderColor: eds.blue[400],
     backgroundColor: T.surface,
     '&:hover': {
+      borderColor: eds.blue[400],
       backgroundColor: T.surface
+    }
+  },
+  nextButton: {
+    backgroundColor: eds.blue[400],
+    color: T.surface,
+    '&:hover': {
+      backgroundColor: eds.blue[600]
     }
   },
   title: {
@@ -154,11 +168,12 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   intro: {
     color: T.muted,
+    fontSize: 16,
     marginTop: theme.spacing(2)
   },
   stepRow: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: theme.spacing(2),
     marginTop: theme.spacing(3)
   },
@@ -175,27 +190,42 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   stepTitle: {
     color: T.ink,
+    fontSize: 16,
     fontWeight: 700
   },
   stepDesc: {
-    color: T.muted
+    color: T.muted,
+    fontSize: 16
   },
   error: {
     marginTop: theme.spacing(2),
     color: theme.palette.error.main
   },
   sectionText: {
-    color: T.muted,
+    color: T.ink,
+    fontSize: 16,
     marginTop: theme.spacing(2),
     lineHeight: 1.6
   },
   subTitle: {
     color: T.ink,
+    fontSize: 22,
     fontWeight: 700,
     marginTop: theme.spacing(3)
   },
+  sectionLead: {
+    color: T.ink,
+    fontSize: 16,
+    fontWeight: 700,
+    marginTop: theme.spacing(3)
+  },
+  rowLabel: {
+    color: T.ink,
+    fontSize: 16
+  },
   list: {
-    color: T.muted,
+    color: T.ink,
+    fontSize: 16,
     marginTop: theme.spacing(1.5),
     paddingLeft: theme.spacing(3),
     lineHeight: 1.6,
@@ -207,7 +237,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
     display: 'inline-flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
-    color: theme.palette.primary.main,
+    color: eds.blue[400],
+    fontSize: 16,
     fontWeight: 600,
     textDecoration: 'none',
     '&:hover': {
@@ -221,19 +252,21 @@ const useStyles = makeStyles()((theme: Theme) => ({
     marginTop: theme.spacing(2)
   },
   divider: {
-    marginTop: theme.spacing(3)
+    marginTop: theme.spacing(3),
+    borderColor: eds.blue[200]
   },
   infoRow: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: theme.spacing(1.5),
     marginTop: theme.spacing(3)
   },
   infoBadge: {
-    marginTop: theme.spacing(0.25)
+    flexShrink: 0
   },
   infoText: {
-    color: theme.palette.primary.main,
+    color: eds.blue[800],
+    fontSize: 16,
     lineHeight: 1.6
   },
   loadingRow: {
@@ -279,22 +312,17 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   warningNotice: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: theme.spacing(1.5),
     marginTop: theme.spacing(3)
   },
   warningBadge: {
-    marginTop: theme.spacing(-0.25)
+    flexShrink: 0
   },
   warningText: {
     color: T.warning,
     fontWeight: 600,
     lineHeight: 1.5
-  },
-  bareTitle: {
-    color: T.deepBlue,
-    fontWeight: 700,
-    marginBottom: theme.spacing(4)
   },
   illustrationRow: {
     display: 'flex',

--- a/src/views/Onboarding/tokens.ts
+++ b/src/views/Onboarding/tokens.ts
@@ -1,20 +1,20 @@
-import { eds } from 'styles/palette'
+import { aphp, eds, neutre } from 'styles/palette'
 
 export const onboardingTokens = {
-  ink: '#1F2A37',
-  muted: '#5B6472',
+  ink: neutre[800],
+  muted: neutre[600],
   pageBg: eds.blue[50],
   surface: '#FFFFFF',
   cardBorder: eds.blue[200],
-  stepIconBg: '#FBE7D5',
-  stepIconFg: '#C77B3B',
+  stepIconBg: '#FDDDBF',
+  stepIconFg: aphp.jaune[900],
   avatarBg: '#5BC5F2',
   tileBg: '#F5F8FE',
   warning: '#E5007D',
   deepBlue: '#0062AB',
   documentBg: '#7F7F7F',
-  // Rail: the travelled part is deep blue, what remains is a pale tint of it.
-  railDone: '#1D4F9B',
-  railTodo: '#A9C4EA',
-  railInactiveFg: '#5B6472'
+  // Rail: the travelled part is the dark blue, what remains is the pale blue.
+  railDone: eds.blue[400],
+  railTodo: eds.blue[200],
+  railInactiveFg: neutre[600]
 } as const


### PR DESCRIPTION
## Objectif
Aligner l'onboarding sur les maquettes du design system et introduire la palette de couleurs EDS partagée avec le design.
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3310

## Changements réalisés
- Ajout de `src/styles/palette.ts`, transcription des chartes EDS et AP-HP en tokens nommés.
- Bascule des couleurs de charte du thème et de l'onboarding vers ces tokens.
- Typographie de l'onboarding passée en Rubik.
- Couleurs de l'onboarding recalées sur les maquettes : textes en `neutre`, stepper, liens, message d'info, CTA.
- Stepper sans contour, seul le cercle actif est plein.
- Textes centrés verticalement à côté des icônes.
- Charte d'engagement affichée dans une carte, avec un lien de téléchargement.

## Impacts
Front.

## Tests réalisés
Unitaires.

## Risques
A merge après #1289 
