### PR TITLE
feat(onboarding): déconnexion depuis le parcours et indisponibilité des droits

### DIFF
--- a/src/services/aphp/__tests__/serviceOnboarding.test.ts
+++ b/src/services/aphp/__tests__/serviceOnboarding.test.ts
@@ -56,6 +56,16 @@ describe('serviceOnboarding', () => {
     expect(get).toHaveBeenCalledWith('accesses/rights/')
   })
 
+  it('rejects when the accesses request is swallowed by the interceptor', async () => {
+    get.mockResolvedValue(new Error('Request failed with status code 503'))
+    await expect(serviceOnboarding.getMyAccesses()).rejects.toThrow()
+  })
+
+  it('rejects when the rights catalog request is swallowed by the interceptor', async () => {
+    get.mockResolvedValue(new Error('Request failed with status code 503'))
+    await expect(serviceOnboarding.getRightsCatalog()).rejects.toThrow()
+  })
+
   it('returns the current onboarding status', async () => {
     get.mockResolvedValue({
       data: { onboarding_step: 3, onboarding_completed_at: '2026-06-29T10:00:00Z', charter_signed_at: null }

--- a/src/services/aphp/serviceOnboarding.ts
+++ b/src/services/aphp/serviceOnboarding.ts
@@ -39,14 +39,8 @@ const serviceOnboarding: IServiceOnboarding = {
   updateStep: async (step) =>
     requireData(await apiBackend.patch<OnboardingProgress>('/users/me/onboarding/', { onboarding_step: step })),
   signCharter: async () => requireData(await apiBackend.post<CharterSignature>('/users/me/onboarding/charter/')),
-  getMyAccesses: async () => {
-    const { data } = await apiBackend.get<MyAccess[]>('accesses/accesses/my-accesses/')
-    return data
-  },
-  getRightsCatalog: async () => {
-    const { data } = await apiBackend.get<RightCatalogCategory[]>('accesses/rights/')
-    return data
-  },
+  getMyAccesses: async () => requireData(await apiBackend.get<MyAccess[]>('accesses/accesses/my-accesses/')),
+  getRightsCatalog: async () => requireData(await apiBackend.get<RightCatalogCategory[]>('accesses/rights/')),
   getStatus: async () => requireData(await apiBackend.get<OnboardingStatus>('/users/me/onboarding/'))
 }
 

--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -1,36 +1,24 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import { Avatar, Box, Button, Typography } from '@mui/material'
+import { Button, Typography } from '@mui/material'
 import logo from 'assets/images/logo-login.png'
 import useOnboardingStatus from 'hooks/onboarding/useOnboardingStatus'
 import React from 'react'
 import { Navigate } from 'react-router-dom'
-import { useAppSelector } from 'state'
 
 import { OnboardingProvider, useOnboarding } from './OnboardingContext'
 import StepPlaceholder from './StepPlaceholder'
 import { ONBOARDING_STEPS } from './steps'
 import useStyles from './styles'
+import UserMenu from './UserMenu'
 import WelcomeScreen from './WelcomeScreen'
 import WizardShell from './WizardShell'
 
 const PROGRESS_ERROR_MESSAGE =
   "Une erreur est survenue lors de l'enregistrement de votre progression. Veuillez réessayer."
 
-const getInitials = (name?: string) =>
-  name
-    ? name
-        .trim()
-        .split(/\s+/)
-        .map((word) => word[0])
-        .slice(0, 2)
-        .join('')
-        .toUpperCase()
-    : ''
-
 const OnboardingLayout = () => {
   const { classes } = useStyles()
-  const displayName = useAppSelector((state) => state.me?.displayName)
   const { screen, currentStep, screenConfig, stepProgress, primaryLabel, saving, error, goNext, goBack } =
     useOnboarding()
 
@@ -40,12 +28,7 @@ const OnboardingLayout = () => {
   const header = (
     <>
       <img className={classes.logo} src={logo} alt="Logo Cohort360" />
-      {displayName && (
-        <Box className={classes.userBox}>
-          <Avatar className={classes.avatar}>{getInitials(displayName)}</Avatar>
-          <Typography className={classes.user}>{displayName}</Typography>
-        </Box>
-      )}
+      <UserMenu />
     </>
   )
 

--- a/src/views/Onboarding/UserMenu.tsx
+++ b/src/views/Onboarding/UserMenu.tsx
@@ -1,0 +1,63 @@
+import { Avatar, ButtonBase, Menu, MenuItem, Typography } from '@mui/material'
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useAppDispatch, useAppSelector } from 'state'
+import { logout } from 'state/me'
+
+import useStyles from './styles'
+
+const getInitials = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+
+const UserMenu = () => {
+  const { classes } = useStyles()
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+  const displayName = useAppSelector((state) => state.me?.displayName)
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+
+  if (!displayName) {
+    return null
+  }
+
+  const onLogout = () => {
+    setAnchorEl(null)
+    dispatch(logout())
+    navigate('/')
+  }
+
+  return (
+    <>
+      <ButtonBase
+        className={classes.userBox}
+        aria-haspopup="menu"
+        aria-expanded={anchorEl !== null}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+      >
+        <Avatar className={classes.avatar}>{getInitials(displayName)}</Avatar>
+        <Typography className={classes.user}>{displayName}</Typography>
+      </ButtonBase>
+      <Menu
+        anchorEl={anchorEl}
+        open={anchorEl !== null}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { className: classes.userMenu } }}
+      >
+        <MenuItem className={classes.userMenuItem} onClick={onLogout}>
+          Se déconnecter
+        </MenuItem>
+      </Menu>
+    </>
+  )
+}
+
+export default UserMenu

--- a/src/views/Onboarding/UserMenu.tsx
+++ b/src/views/Onboarding/UserMenu.tsx
@@ -27,10 +27,10 @@ const UserMenu = () => {
     return null
   }
 
-  const onLogout = () => {
+  const onLogout = async () => {
     setAnchorEl(null)
-    dispatch(logout())
-    navigate('/')
+    await dispatch(logout())
+    navigate('/', { replace: true })
   }
 
   return (

--- a/src/views/Onboarding/__tests__/UserMenu.test.tsx
+++ b/src/views/Onboarding/__tests__/UserMenu.test.tsx
@@ -57,6 +57,30 @@ describe('UserMenu (US-3384)', () => {
     expect(screen.getByText('login page')).toBeInTheDocument()
   })
 
+  it('redirects to the login page only once the logout has completed (RG3384.02)', async () => {
+    let resolveLogout: () => void = () => undefined
+    practitionerLogout.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = () => resolve()
+        })
+    )
+    const user = userEvent.setup()
+    const store = renderUserMenu()
+
+    await user.click(screen.getByRole('button', { name: /Cesar RICHARD/ }))
+    await user.click(screen.getByRole('menuitem', { name: 'Se déconnecter' }))
+
+    await waitFor(() => expect(practitionerLogout).toHaveBeenCalled())
+    expect(screen.queryByText('login page')).not.toBeInTheDocument()
+    expect(store.getState().me).not.toBeNull()
+
+    resolveLogout()
+
+    await waitFor(() => expect(store.getState().me).toBeNull())
+    expect(screen.getByText('login page')).toBeInTheDocument()
+  })
+
   it('renders nothing when no user is connected', () => {
     renderUserMenu(null)
     expect(screen.queryByRole('button')).not.toBeInTheDocument()

--- a/src/views/Onboarding/__tests__/UserMenu.test.tsx
+++ b/src/views/Onboarding/__tests__/UserMenu.test.tsx
@@ -1,0 +1,64 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { practitionerLogout } = vi.hoisted(() => ({ practitionerLogout: vi.fn() }))
+
+vi.mock('services/aphp', () => ({
+  default: { practitioner: { logout: practitionerLogout } }
+}))
+
+import meReducer, { type MeState } from 'state/me'
+import UserMenu from '../UserMenu'
+
+const renderUserMenu = (me: MeState = { displayName: 'Cesar RICHARD' } as MeState) => {
+  const store = configureStore({ reducer: { me: meReducer }, preloadedState: { me } })
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/onboarding']}>
+        <Routes>
+          <Route path="/onboarding" element={<UserMenu />} />
+          <Route path="/" element={<div>login page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  )
+  return store
+}
+
+describe('UserMenu (US-3384)', () => {
+  beforeEach(() => {
+    practitionerLogout.mockReset()
+    practitionerLogout.mockResolvedValue(undefined)
+  })
+
+  it('opens the logout action on a click on the user name (RG3384.01)', async () => {
+    const user = userEvent.setup()
+    renderUserMenu()
+
+    expect(screen.queryByRole('menuitem', { name: 'Se déconnecter' })).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /Cesar RICHARD/ }))
+    expect(screen.getByRole('menuitem', { name: 'Se déconnecter' })).toBeInTheDocument()
+  })
+
+  it('ends the session and goes back to the login page (RG3384.02)', async () => {
+    const user = userEvent.setup()
+    const store = renderUserMenu()
+
+    await user.click(screen.getByRole('button', { name: /Cesar RICHARD/ }))
+    await user.click(screen.getByRole('menuitem', { name: 'Se déconnecter' }))
+
+    await waitFor(() => expect(practitionerLogout).toHaveBeenCalled())
+    await waitFor(() => expect(store.getState().me).toBeNull())
+    expect(screen.getByText('login page')).toBeInTheDocument()
+  })
+
+  it('renders nothing when no user is connected', () => {
+    renderUserMenu(null)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})

--- a/src/views/Onboarding/screens/environment/UserRights.tsx
+++ b/src/views/Onboarding/screens/environment/UserRights.tsx
@@ -1,5 +1,5 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import { Box, CircularProgress, Typography } from '@mui/material'
+import { Box, CircularProgress, Link, Typography } from '@mui/material'
 import moment from 'moment'
 import React from 'react'
 
@@ -7,6 +7,8 @@ import { useAppSelector } from 'state'
 
 import useStyles from '../../styles'
 import { useUserAccesses } from './useUserAccesses'
+
+const SUPPORT_MAIL = 'id.recherche.support.dsn@aphp.fr'
 
 const UserRights = () => {
   const { classes } = useStyles()
@@ -30,12 +32,20 @@ const UserRights = () => {
     )
   }
 
-  if (hasError) {
+  // Un appel en échec comme un périmètre vide laissent l'écran sans rien à montrer : même message,
+  // et le parcours reste franchissable.
+  if (hasError || accesses.length === 0) {
     return (
       <Box>
         {title}
-        <Typography role="alert" className={classes.error}>
-          Une erreur est survenue lors de la récupération de vos droits d'accès. Veuillez réessayer ultérieurement.
+        <Typography role="status" className={classes.sectionText}>
+          Le détail de votre accès à Cohort360 n'est pas disponible pour le moment.
+        </Typography>
+        <Typography className={classes.sectionText}>
+          Pour en savoir plus sur vos droits et votre périmètre accessible dans l'application, contactez le support :{' '}
+          <Link className={classes.inlineLink} href={`mailto:${SUPPORT_MAIL}`}>
+            {SUPPORT_MAIL}
+          </Link>
         </Typography>
       </Box>
     )

--- a/src/views/Onboarding/screens/environment/__tests__/UserRights.test.tsx
+++ b/src/views/Onboarding/screens/environment/__tests__/UserRights.test.tsx
@@ -110,9 +110,29 @@ describe('UserRights (US-3307)', () => {
     expect(await screen.findByText('Non renseignée')).toBeInTheDocument()
   })
 
-  it('shows an error message when a call fails', async () => {
+  it('tells the user his access details are unavailable when a call fails (RG3381.01)', async () => {
     getRightsCatalog.mockRejectedValue(new Error('boom'))
     renderUserRights()
-    expect(await screen.findByRole('alert')).toHaveTextContent(/Une erreur est survenue/)
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /Le détail de votre accès à Cohort360 n'est pas disponible/
+    )
+  })
+
+  it('points to the support without blocking the journey (RG3381.02)', async () => {
+    getMyAccesses.mockRejectedValue(new Error('boom'))
+    renderUserRights()
+    await screen.findByRole('status')
+    expect(screen.getByRole('link', { name: 'id.recherche.support.dsn@aphp.fr' })).toHaveAttribute(
+      'href',
+      'mailto:id.recherche.support.dsn@aphp.fr'
+    )
+  })
+
+  it('shows the same message when the API answers without any access', async () => {
+    getMyAccesses.mockResolvedValue([])
+    renderUserRights()
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /Le détail de votre accès à Cohort360 n'est pas disponible/
+    )
   })
 })

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -259,6 +259,11 @@ const useStyles = makeStyles()((theme: Theme) => ({
       textDecoration: 'underline'
     }
   },
+  inlineLink: {
+    color: eds.blue[400],
+    fontWeight: 600,
+    textDecoration: 'underline'
+  },
   linkIcon: {
     fontSize: 16
   },

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -30,7 +30,21 @@ const useStyles = makeStyles()((theme: Theme) => ({
   userBox: {
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1.5)
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(0.5, 1),
+    borderRadius: 6,
+    '&:hover': {
+      backgroundColor: eds.blue[50]
+    }
+  },
+  userMenu: {
+    marginTop: theme.spacing(1),
+    borderRadius: 6
+  },
+  userMenuItem: {
+    fontFamily: FONT,
+    color: T.ink,
+    padding: theme.spacing(1.5, 3)
   },
   avatar: {
     width: 36,


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3384
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3381

## Changements réalisés
Le nom de l'utilisateur dans l'en-tête du parcours ouvre un menu avec une action `Se déconnecter`, qui met fin à la session et renvoie sur la page de connexion.

Sur l'écran des droits, un appel en échec à l'API My-Right ou une réponse sans aucun accès affiche un message d'indisponibilité et l'adresse du support. Les appels `my-accesses` et `rights` passent désormais par `requireData`, l'échec n'étant jusque-là détecté qu'indirectement.

## Impacts
Front, écrans d'onboarding uniquement.

## Tests réalisés
Unitaires.

## Risques
None