### PR TITLE
fix(cohortCreation): expand wildcard CCAM codes to their declensions (3388)

### DIFF
--- a/src/__tests__/mappers/chipDisplayMapper.test.ts
+++ b/src/__tests__/mappers/chipDisplayMapper.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { CHIPS_DISPLAY_METHODS } from 'components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { updateConfig } from 'config'
 
 const CCAM = 'https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP'
+
+import { CHIPS_DISPLAY_METHODS } from 'components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper'
 
 const valueSets = {
   entities: {},
@@ -11,6 +13,10 @@ const valueSets = {
 const item = { valueSetsInfo: [{ url: CCAM }] } as any
 
 describe('CHIPS_DISPLAY_METHODS.codeSearch', () => {
+  beforeAll(() => {
+    updateConfig({ features: { procedure: { valueSets: { procedureHierarchy: { url: CCAM } } } } })
+  })
+
   it('builds a chip when the stored code resolves in cache', () => {
     const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: '000742', system: CCAM }] as any, item, valueSets, ['', false])
     expect(chip).toBeTruthy()
@@ -22,5 +28,22 @@ describe('CHIPS_DISPLAY_METHODS.codeSearch', () => {
       false
     ])
     expect(chip).toBeTruthy()
+  })
+
+  it('lists every declension of a wildcard code and hides the wildcard itself', () => {
+    const segmented = {
+      entities: {},
+      cache: {
+        [CCAM]: [
+          { id: 'JQGA004...01', label: 'Cesarienne activite 1', system: CCAM },
+          { id: 'JQGA004-1201', label: 'Cesarienne unique', system: CCAM }
+        ]
+      }
+    } as any
+    const chip = CHIPS_DISPLAY_METHODS.codeSearch([{ id: 'JQGA004*', system: CCAM }] as any, item, segmented, ['', false])
+
+    expect(JSON.stringify(chip)).toContain('Cesarienne activite 1')
+    expect(JSON.stringify(chip)).toContain('Cesarienne unique')
+    expect(JSON.stringify(chip)).not.toContain('JQGA004*')
   })
 })

--- a/src/__tests__/mappers/renderers.codeSearch.test.tsx
+++ b/src/__tests__/mappers/renderers.codeSearch.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { updateConfig } from 'config'
+
+const CCAM = 'https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP'
+
+const declensions = [
+  { id: 'JQGA004...01', label: 'Activite 1', system: CCAM },
+  { id: 'JQGA004...04', label: 'Activite 4', system: CCAM },
+  { id: 'JQGA004-1201', label: 'Accouchement unique', system: CCAM }
+]
+
+vi.mock('state', () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({ valueSets: { cache: { [CCAM]: declensions }, entities: {} } })
+}))
+
+vi.mock('state/valueSets', () => ({ selectValueSetCodes: () => [] }))
+
+vi.mock('components/SearchValueSet/ValueSetField', () => ({
+  default: ({ value }: { value: { id: string }[] }) => <div data-testid="field">{value.map((c) => c.id).join(',')}</div>
+}))
+
+import FORM_ITEM_RENDERER from 'components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/renderers'
+
+describe('FORM_ITEM_RENDERER.codeSearch', () => {
+  beforeAll(() => {
+    updateConfig({ features: { procedure: { valueSets: { procedureHierarchy: { url: CCAM } } } } })
+  })
+
+  const renderCodeSearch = (value: { id: string; system: string }[], updateData = vi.fn()) => {
+    const CodeSearch = FORM_ITEM_RENDERER.codeSearch as unknown as React.FC<Record<string, unknown>>
+    return render(
+      <CodeSearch
+        value={value}
+        updateData={updateData}
+        setError={vi.fn()}
+        definition={{ valueSetsInfo: [{ url: CCAM }], label: '' }}
+        disabled={false}
+      />
+    )
+  }
+
+  it('displays every declension of a stored wildcard code', () => {
+    const { getByTestId } = renderCodeSearch([{ id: 'JQGA004*', system: CCAM }])
+
+    const shown = getByTestId('field').textContent ?? ''
+    expect(shown).toContain('JQGA004...01')
+    expect(shown).toContain('JQGA004...04')
+    expect(shown).toContain('JQGA004-1201')
+    expect(shown).toContain('JQGA004*')
+  })
+
+  it('leaves an already segmented code alone', () => {
+    const { getByTestId } = renderCodeSearch([{ id: 'JQGA004...01', system: CCAM }])
+
+    expect(getByTestId('field').textContent).toBe('JQGA004...01')
+  })
+})

--- a/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
+++ b/src/__tests__/utilsFunction/cohortCreation.healCriteriaCodes.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const criteriaMocks = vi.hoisted(() => ({ getAllCriteriaItems: vi.fn() }))
 const valueSetMocks = vi.hoisted(() => ({
   getValueSetFromCodeSystem: vi.fn(),
-  matchStoredCodeInCache: vi.fn()
+  expandStoredCodesInCache: vi.fn()
 }))
 
 vi.mock('components/CreationCohort/DataList_Criteria', () => criteriaMocks)
@@ -23,8 +23,10 @@ describe('healCriteriaCodes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     criteriaMocks.getAllCriteriaItems.mockReturnValue([ccamDefinition])
-    valueSetMocks.matchStoredCodeInCache.mockImplementation((code: any) =>
-      code.id === '000742' ? { id: '000742.....', system: 'https://ccam-vs', label: 'noeud' } : code
+    valueSetMocks.expandStoredCodesInCache.mockImplementation((codes: any[]) =>
+      codes.flatMap((code) =>
+        code.id === '000742' ? [{ id: '000742.....', system: 'https://ccam-vs', label: 'noeud' }] : [code]
+      )
     )
   })
 
@@ -54,5 +56,24 @@ describe('healCriteriaCodes', () => {
     const selectedCriteria = [{ type: 'PROC', code: [] }] as any
 
     expect(healCriteriaCodes([] as any, selectedCriteria, {} as any)).toBe(selectedCriteria)
+  })
+
+  it('expands a wildcard CCAM code into its declensions', () => {
+    valueSetMocks.expandStoredCodesInCache.mockImplementation((codes: any[]) =>
+      codes.flatMap((code) =>
+        code.id === 'JQGA004*'
+          ? [
+              { id: 'JQGA004...01', system: 'https://ccam-vs', label: '01' },
+              { id: 'JQGA004-1201', system: 'https://ccam-vs', label: '1201' },
+              code
+            ]
+          : [code]
+      )
+    )
+    const selectedCriteria = [{ type: 'PROC', code: [{ id: 'JQGA004*', system: 'https://ccam-vs' }] }] as any
+
+    const healed = healCriteriaCodes([] as any, selectedCriteria, {} as any) as any[]
+
+    expect(healed[0].code.map((c: any) => c.id)).toEqual(['JQGA004...01', 'JQGA004-1201', 'JQGA004*'])
   })
 })

--- a/src/__tests__/utilsFunction/valueSets.test.ts
+++ b/src/__tests__/utilsFunction/valueSets.test.ts
@@ -13,7 +13,9 @@ import {
   getSearchSystemUrl,
   checkIsLeaf,
   matchStoredCodeInCache,
-  findCodeByIdOrPrefix
+  findCodeByIdOrPrefix,
+  expandStoredCodeInCache,
+  expandStoredCodesInCache
 } from 'utils/valueSets'
 import { HIERARCHY_ROOT } from 'services/aphp/serviceValueSets'
 import { Hierarchy } from 'types/hierarchy'
@@ -654,6 +656,80 @@ describe('valueSets utilities', () => {
       const stored = { id: 'ZZZZ999', system: CCAM }
       expect(matchStoredCodeInCache(stored, cache, true)).toBe(stored)
     })
+
+    it('keeps a segmented act code as stored', () => {
+      const segmented = {
+        [CCAM]: [item('JQGA004...01', 'Acte 01'), item('JQGA004...04', 'Acte 04'), item('JQGA004-1201', 'Acte 1201')]
+      }
+      const stored = { id: 'JQGA004', label: '', system: CCAM }
+      expect(matchStoredCodeInCache(stored, segmented, true)).toBe(stored)
+    })
+  })
+
+  describe('expandStoredCodeInCache', () => {
+    const CCAM = 'https://ccam'
+    const item = (id: string): Hierarchy<FhirItem> => ({ id, label: id, system: CCAM }) as Hierarchy<FhirItem>
+    const declensions = [item('JQGA004...01'), item('JQGA004...04'), item('JQGA004-1201')]
+
+    it('expands a wildcard code into every declension held in cache', () => {
+      const stored = { id: 'JQGA004*', system: CCAM }
+      const result = expandStoredCodeInCache(stored, { [CCAM]: declensions }, true)
+      expect(result.map((c) => c.id)).toEqual(['JQGA004...01', 'JQGA004...04', 'JQGA004-1201', 'JQGA004*'])
+    })
+
+    it('keeps the wildcard untouched when the cache holds no declension', () => {
+      const stored = { id: 'JQGA004*', system: CCAM }
+      expect(expandStoredCodeInCache(stored, { [CCAM]: [] }, true)).toEqual([stored])
+    })
+
+    it('does not expand a wildcard outside CCAM', () => {
+      const stored = { id: 'JQGA004*', system: CCAM }
+      const result = expandStoredCodeInCache(stored, { [CCAM]: declensions }, false)
+      expect(result).toEqual([stored])
+    })
+
+    it('falls back to the single match for a code without wildcard', () => {
+      const stored = { id: 'JQGA004...01', system: CCAM }
+      const result = expandStoredCodeInCache(stored, { [CCAM]: declensions }, true)
+      expect(result.map((c) => c.id)).toEqual(['JQGA004...01'])
+    })
+  })
+
+  describe('expandStoredCodesInCache', () => {
+    const CCAM = 'https://ccam'
+    const item = (id: string): Hierarchy<FhirItem> => ({ id, label: id, system: CCAM }) as Hierarchy<FhirItem>
+    const declensions = [
+      'JQGA004-2101',
+      'JQGA004-2104',
+      'JQGA004-1101',
+      'JQGA004-1204',
+      'JQGA004...01',
+      'JQGA004-2201',
+      'JQGA004-2204',
+      'JQGA004...04',
+      'JQGA004-1201',
+      'JQGA004-1104'
+    ].map(item)
+
+    it('checks every sibling of a migrated criterion without duplicating the stored ones', () => {
+      const stored = [
+        { id: 'JQGA004...04', system: CCAM },
+        { id: 'JQGA004*', system: CCAM },
+        { id: 'JQGA004...01', system: CCAM }
+      ]
+      const ids = expandStoredCodesInCache(stored, { [CCAM]: declensions }, true).map((code) => code.id)
+
+      expect(new Set(ids).size).toBe(ids.length)
+      declensions.forEach((declension) => expect(ids).toContain(declension.id))
+      expect(ids).toContain('JQGA004*')
+    })
+
+    it('keeps the wildcard alongside a partially loaded cache', () => {
+      const partial = { [CCAM]: [item('JQGA004...01'), item('JQGA004...04')] }
+      const ids = expandStoredCodesInCache([{ id: 'JQGA004*', system: CCAM }], partial, true).map((code) => code.id)
+
+      expect(ids).toEqual(['JQGA004...01', 'JQGA004...04', 'JQGA004*'])
+    })
   })
 
   describe('findCodeByIdOrPrefix', () => {
@@ -677,9 +753,14 @@ describe('valueSets utilities', () => {
       expect(findCodeByIdOrPrefix(list, '001472', true)?.id).toBe('001472.....')
     })
 
-    it('falls back to the shortest prefix match when there is no padding node', () => {
-      const list = [item('EPFA001...12'), item('EPFA001...1')]
-      expect(findCodeByIdOrPrefix(list, 'EPFA001', true)?.id).toBe('EPFA001...1')
+    it('leaves a segmented act code unresolved instead of electing one declension', () => {
+      const list = [item('JQGA004...01'), item('JQGA004...04'), item('JQGA004-1201')]
+      expect(findCodeByIdOrPrefix(list, 'JQGA004', true)).toBeUndefined()
+    })
+
+    it('returns undefined when a node has no padding successor', () => {
+      const list = [item('001472.001'), item('001472.0012')]
+      expect(findCodeByIdOrPrefix(list, '001472', true)).toBeUndefined()
     })
 
     it('ignores undefined entries in the list', () => {

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/chipDisplayMapper.tsx
@@ -24,7 +24,7 @@ import allDocTypes from 'assets/docTypes.json'
 import moment from 'moment'
 import { getDurationRangeLabel } from 'utils/age'
 import { getConfig } from 'config'
-import { getValueSetFromCodeSystem, findCodeByIdOrPrefix } from 'utils/valueSets'
+import { getValueSetFromCodeSystem, expandStoredCodeInCache } from 'utils/valueSets'
 
 /************************************************************************************/
 /*                        Criteria Form Item Chip Display                           */
@@ -146,7 +146,7 @@ const getLabelsForCodeSearchItem = (
   const ccamHierarchyUrl = getConfig().features.procedure.valueSets.procedureHierarchy?.url
   const allowPrefixMatch = !!ccamHierarchyUrl && item.valueSetsInfo.some((ref) => ref.url === ccamHierarchyUrl)
   return val
-    .map((value) => {
+    .flatMap((value) => {
       let cacheKey: string | undefined
 
       if (value.system) {
@@ -163,7 +163,10 @@ const getLabelsForCodeSearchItem = (
       const codeList = cacheKey
         ? valueSets.cache[cacheKey]
         : item.valueSetsInfo.flatMap((valueset) => valueSets.cache[valueset.url])
-      return findCodeByIdOrPrefix(codeList || [], value.id, allowPrefixMatch) as LabelObject
+      const scope = { [cacheKey ?? '']: codeList || [] }
+      return expandStoredCodeInCache(value, scope, allowPrefixMatch).filter(
+        (code) => !code.id.endsWith('*')
+      ) as LabelObject[]
     })
     .filter((code) => code !== undefined)
 }

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/renderers.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/renderers.tsx
@@ -27,7 +27,7 @@ import { CriteriaLabel } from 'components/ui/CriteriaLabel'
 import { Comparators } from 'types/requestCriterias'
 import SimpleSelect from 'components/ui/Inputs/SimpleSelect'
 import ValueSetField from 'components/SearchValueSet/ValueSetField'
-import { checkIsLeaf, matchStoredCodeInCache } from 'utils/valueSets'
+import { checkIsLeaf, expandStoredCodesInCache } from 'utils/valueSets'
 import { getConfig } from 'config'
 import { selectValueSetCodes } from 'state/valueSets'
 import SearchbarWithCheck from 'components/ui/Searchbar/SearchbarWithChecks'
@@ -328,9 +328,7 @@ const FORM_ITEM_RENDERER: { [key in CriteriaFormItemType]: CriteriaFormItemView<
     const ccamHierarchyUrl = getConfig().features.procedure.valueSets.procedureHierarchy?.url
     const allowPrefixMatch =
       !!ccamHierarchyUrl && props.definition.valueSetsInfo.some((ref) => ref.url === ccamHierarchyUrl)
-    const valueWithLabels = (props.value ?? []).map((code) =>
-      matchStoredCodeInCache(code, codeCaches, allowPrefixMatch)
-    )
+    const valueWithLabels = expandStoredCodesInCache(props.value ?? [], codeCaches, allowPrefixMatch)
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [valueBuffer, setValueBuffer] = useState(valueWithLabels)
 

--- a/src/utils/cohortCreation.ts
+++ b/src/utils/cohortCreation.ts
@@ -43,12 +43,12 @@ import { getChildrenFromCodes, HIERARCHY_ROOT } from 'services/aphp/serviceValue
 import { createHierarchyRoot } from './hierarchy'
 import { FhirItem } from 'types/valueSet'
 import { ScopeElement } from 'types/scope'
-import { getValueSetFromCodeSystem, matchStoredCodeInCache } from './valueSets'
+import { getValueSetFromCodeSystem, expandStoredCodesInCache } from './valueSets'
 import { formatAge } from './age'
 import { getConfig } from 'config'
 
 /** Current version of the Requeteur format used for cohort requests */
-const REQUETEUR_VERSION = 'v1.6.3'
+const REQUETEUR_VERSION = 'v1.6.4'
 
 /** Default criteria group used as fallback when group lookup fails */
 const DEFAULT_GROUP_ERROR: CriteriaGroup = {
@@ -875,15 +875,12 @@ export const healCriteriaCodes = (
         const values = next[dataKey] as unknown as LabelObject[] | undefined
         if (!values?.length) continue
         const allowPrefixMatch = !!ccamHierarchyUrl && item.valueSetsInfo.some((ref) => ref.url === ccamHierarchyUrl)
-        let fieldChanged = false
-        const healedValues = values.map((code) => {
-          const match = matchStoredCodeInCache(code, cache, allowPrefixMatch) as LabelObject
-          if (match.id !== code.id || match.system !== code.system) {
-            fieldChanged = true
-            return match
-          }
-          return code
-        })
+        const healedValues = expandStoredCodesInCache(values, cache, allowPrefixMatch) as LabelObject[]
+        const fieldChanged =
+          healedValues.length !== values.length ||
+          healedValues.some(
+            (healedCode, index) => healedCode.id !== values[index].id || healedCode.system !== values[index].system
+          )
         if (fieldChanged) {
           changed = true
           next = { ...next, [dataKey]: healedValues }

--- a/src/utils/valueSets.ts
+++ b/src/utils/valueSets.ts
@@ -21,20 +21,21 @@ export const getValueSetFromCodeSystem = (codeSystemUrl: string): string | undef
   return reference?.url
 }
 
-// Match exact, sinon (CCAM) par préfixe : le noeud ré-encodé a un suffixe tout en points (`001472.....`),
-// préféré à ses descendants (`001472.001`). Désactivé hors CCAM pour éviter CIM10 `E11`/`E110`.
+// Chapitre CCAM : le ré-encodage lui a ajouté un suffixe tout en points, donc un seul successeur.
+const CCAM_NODE_CODE_RE = /^[0-9]{6}$/
+
+// Match exact, sinon `001472` -> `001472.....`, préféré à ses descendants `001472.001`. Un acte est
+// segmenté en plusieurs déclinaisons : en élire une restreindrait la sélection, on le laisse intact.
+// Désactivé hors CCAM pour éviter CIM10 `E11`/`E110`.
 export const findCodeByIdOrPrefix = (
   codes: readonly (Hierarchy<FhirItem> | undefined)[],
   id: string,
   allowPrefixMatch: boolean
 ): Hierarchy<FhirItem> | undefined => {
   const exact = codes.find((c) => c?.id === id)
-  if (exact || !allowPrefixMatch || !id) return exact
+  if (exact || !allowPrefixMatch || !id || !CCAM_NODE_CODE_RE.test(id)) return exact
   const prefixMatches = codes.filter((c): c is Hierarchy<FhirItem> => typeof c?.id === 'string' && c.id.startsWith(id))
-  return (
-    prefixMatches.find((c) => /^\.*$/.test(c.id.slice(id.length))) ??
-    [...prefixMatches].sort((a, b) => a.id.length - b.id.length)[0]
-  )
+  return prefixMatches.find((c) => /^\.*$/.test(c.id.slice(id.length)))
 }
 
 // Associe un code stocké au concept du cache (exact puis préfixe CCAM), sinon renvoie le code tel quel.
@@ -46,6 +47,39 @@ export const matchStoredCodeInCache = <T extends { id: string; system?: string }
   const allCodes = Object.values(codeCaches).flat()
   const scope = (code.system ? codeCaches[code.system] : undefined) ?? allCodes
   return findCodeByIdOrPrefix(scope, code.id, allowPrefixMatch) ?? allCodes.find((c) => c.id === code.id) ?? code
+}
+
+// `JQGA004*` vise toutes les déclinaisons de l'acte. On ajoute celles du cache pour qu'elles soient
+// cochées, en gardant l'étoile : sur un cache partiel, la retirer amputerait la sélection à la sauvegarde.
+export const expandStoredCodeInCache = <T extends { id: string; system?: string }>(
+  code: T,
+  codeCaches: Record<string, Hierarchy<FhirItem>[]>,
+  allowPrefixMatch: boolean
+): Array<Hierarchy<FhirItem> | T> => {
+  if (!allowPrefixMatch || !code.id.endsWith('*')) return [matchStoredCodeInCache(code, codeCaches, allowPrefixMatch)]
+  const root = code.id.slice(0, -1)
+  if (!root) return [code]
+  const allCodes = Object.values(codeCaches).flat()
+  const scope = (code.system ? codeCaches[code.system] : undefined) ?? allCodes
+  const declensions = scope.filter((c) => typeof c?.id === 'string' && c.id !== root && c.id.startsWith(root))
+  return [...declensions, code]
+}
+
+// Un acte peut être visé à la fois par son étoile et par une déclinaison déjà stockée, d'où le dédoublonnage.
+export const expandStoredCodesInCache = <T extends { id: string; system?: string }>(
+  codes: readonly T[],
+  codeCaches: Record<string, Hierarchy<FhirItem>[]>,
+  allowPrefixMatch: boolean
+): Array<Hierarchy<FhirItem> | T> => {
+  const seen = new Set<string>()
+  return codes
+    .flatMap((code) => expandStoredCodeInCache(code, codeCaches, allowPrefixMatch))
+    .filter((code) => {
+      const key = `${code.system ?? ''}|${code.id}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
 }
 
 // Helper function to get ValueSet Reference from CodeSystem URL


### PR DESCRIPTION
## Objectif
À l'ouverture d'une requête, un code d'acte CCAM était résolu vers une seule de ses déclinaisons, choisie selon l'ordre du cache, écartant notamment les codes au format tiret.
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3388
Related to https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3371

## Changements réalisés
`findCodeByIdOrPrefix` limite la résolution par préfixe aux chapitres numériques. `expandStoredCodesInCache` complète un code stocké en joker par ses déclinaisons présentes en cache, dédoublonnées et sans retirer le joker. Utilisée par le rendu du critère, `healCriteriaCodes` et les chips. Version du requêteur portée à v1.6.4.

## Impacts
Front. Les critères CCAM d'une requête existante sont réécrits à son ouverture.

## Tests réalisés
Unitaires.

## Risques
À déployer avant la migration back v164.
