### PR TITLE
fix(cohortCreation): hide wildcard CCAM code from the criteria selection field

### DIFF
--- a/src/__tests__/mappers/renderers.codeSearch.test.tsx
+++ b/src/__tests__/mappers/renderers.codeSearch.test.tsx
@@ -42,14 +42,22 @@ describe('FORM_ITEM_RENDERER.codeSearch', () => {
     )
   }
 
-  it('displays every declension of a stored wildcard code', () => {
+  it('displays the declensions of a stored wildcard code without the wildcard itself', () => {
     const { getByTestId } = renderCodeSearch([{ id: 'JQGA004*', system: CCAM }])
 
     const shown = getByTestId('field').textContent ?? ''
     expect(shown).toContain('JQGA004...01')
     expect(shown).toContain('JQGA004...04')
     expect(shown).toContain('JQGA004-1201')
-    expect(shown).toContain('JQGA004*')
+    expect(shown).not.toContain('JQGA004*')
+  })
+
+  it('keeps the wildcard code in the persisted value', () => {
+    const updateData = vi.fn()
+    renderCodeSearch([{ id: 'JQGA004*', system: CCAM }], updateData)
+
+    const saved = (updateData.mock.calls.at(-1)?.[0] ?? []) as { id: string }[]
+    expect(saved.some((code) => code.id === 'JQGA004*')).toBe(true)
   })
 
   it('leaves an already segmented code alone', () => {

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/renderers.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/components/CriteriaRightPanel/CriteriaForm/mappers/renderers.tsx
@@ -329,6 +329,7 @@ const FORM_ITEM_RENDERER: { [key in CriteriaFormItemType]: CriteriaFormItemView<
     const allowPrefixMatch =
       !!ccamHierarchyUrl && props.definition.valueSetsInfo.some((ref) => ref.url === ccamHierarchyUrl)
     const valueWithLabels = expandStoredCodesInCache(props.value ?? [], codeCaches, allowPrefixMatch)
+    const displayedCodes = valueWithLabels.filter((code) => !code.id.endsWith('*'))
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [valueBuffer, setValueBuffer] = useState(valueWithLabels)
 
@@ -354,7 +355,7 @@ const FORM_ITEM_RENDERER: { [key in CriteriaFormItemType]: CriteriaFormItemView<
 
     return (
       <ValueSetField
-        value={valueWithLabels}
+        value={displayedCodes}
         references={props.definition.valueSetsInfo}
         onSelect={(value) => {
           setValueBuffer(value)


### PR DESCRIPTION
## Objectif
Le code joker CCAM (`PREFIX*`) d'un acte segmenté s'affichait comme une chip trompeuse sans libellé dans le champ de sélection d'un critère.

Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3391

## Changements réalisés
Le champ de sélection n'affiche plus le code joker, seulement ses déclinaisons. Le joker reste dans la valeur sauvegardée.

## Impacts
Front.

## Tests réalisés
Unitaires.

## Risques
RAS.