### PR TITLE
fix(exports): désactive le proxy buffering sur la route download

### DIFF
--- a/.templates/nginx.conf
+++ b/.templates/nginx.conf
@@ -47,6 +47,12 @@ server {
         proxy_pass {BACK_URL};
     }
 
+    location /api/back/exports/ {
+        proxy_pass {BACK_URL}exports/;
+        proxy_buffering off;
+        proxy_max_temp_file_size 0;
+    }
+
     location /api/portail/ {
         proxy_pass {BACK_URL};
     }


### PR DESCRIPTION
## Objectif
Le download des gros exports est tronqué à ~1Go par le buffering nginx en amont.

## Changements réalisés
location /api/back/exports/ en pass-through (proxy_buffering off, proxy_max_temp_file_size 0).

## Impacts
Exports.

## Tests réalisés
nginx -t.

## Risques
Config bakée dans l'image.