### PR TITLE
perf(exports): éviter les Blobs pour les téléchargements volumineux

### DIFF
--- a/.templates/nginx.conf
+++ b/.templates/nginx.conf
@@ -51,6 +51,9 @@ server {
         proxy_pass {BACK_URL}exports/;
         proxy_buffering off;
         proxy_max_temp_file_size 0;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        add_header X-Accel-Buffering no always;
     }
 
     location /api/portail/ {

--- a/src/services/aphp/serviceExportCohort.test.ts
+++ b/src/services/aphp/serviceExportCohort.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { post, getUri } = vi.hoisted(() => ({
+  post: vi.fn(),
+  getUri: vi.fn()
+}))
+
+vi.mock('services/apiBackend', () => ({
+  default: { post, getUri }
+}))
+
+vi.mock('services/aphp/callApi', () => ({
+  fetchExportTableInfo: vi.fn(),
+  fetchExportTableRelationInfo: vi.fn(),
+  fetchExportList: vi.fn(),
+  retryExport: vi.fn()
+}))
+
+vi.mock('config', () => ({
+  getConfig: () => ({ features: { export: { exportTables: [] } } })
+}))
+
+import { downloadExport } from './serviceExportCohort'
+
+describe('downloadExport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    post.mockResolvedValue({ data: { expires_in: 60 } })
+    getUri.mockReturnValue('/api/back/exports/export-id/download/')
+  })
+
+  it('requests a ticket then starts a native browser download', async () => {
+    const signal = new AbortController().signal
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined)
+
+    await downloadExport('export-id', signal)
+
+    expect(post).toHaveBeenCalledWith('/exports/export-id/download-ticket/', undefined, { signal })
+    expect(getUri).toHaveBeenCalledWith({ url: '/exports/export-id/download/' })
+    expect(click).toHaveBeenCalledOnce()
+    expect(document.querySelector('a')).toBeNull()
+
+    click.mockRestore()
+  })
+
+  it('does not start a download when ticket creation fails', async () => {
+    post.mockRejectedValue(new Error('ticket unavailable'))
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined)
+
+    await expect(downloadExport('export-id')).rejects.toThrow('ticket unavailable')
+    expect(click).not.toHaveBeenCalled()
+
+    click.mockRestore()
+  })
+})

--- a/src/services/aphp/serviceExportCohort.ts
+++ b/src/services/aphp/serviceExportCohort.ts
@@ -44,48 +44,21 @@ export const fetchExportTablesRelationsInfo = async (tableList: string[]) => {
 }
 
 /**
- * Extracts the filename from the Content-Disposition header.
- * @param contentDisposition  The Content-Disposition header value from which to extract the filename.
- * @returns {string}  The extracted filename, or a default name if extraction fails.
- */
-const extractFilename = (contentDisposition: string): string => {
-  const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
-  const matches = filenameRegex.exec(contentDisposition)
-  let default_filename = 'Download.zip'
-  if (matches?.[1]) {
-    default_filename = matches[1].replaceAll(/['"]/g, '')
-  }
-  return default_filename
-}
-
-/**
- *  Downloads the exported file for the given export ID.
+ * Requests a short-lived HttpOnly download ticket, then delegates the transfer
+ * to the browser download manager so multi-GB files are never materialized as a Blob.
  * @param id The ID of the export to download.
- * @param signal An optional AbortSignal to cancel the download request if needed.
+ * @param signal An optional AbortSignal to cancel ticket creation.
  */
 export const downloadExport = async (id: string, signal?: AbortSignal) => {
-  try {
-    const downloadResponse = await apiBackend.get(`/exports/${id}/download/`, {
-      responseType: 'blob',
-      signal
-    })
+  await apiBackend.post(`/exports/${id}/download-ticket/`, undefined, { signal })
 
-    const filename = extractFilename(downloadResponse.headers['content-disposition'])
-    const blob = new Blob([downloadResponse.data], { type: 'application/zip' })
+  const link = document.createElement('a')
+  link.href = apiBackend.getUri({ url: `/exports/${id}/download/` })
+  link.rel = 'noopener'
 
-    const url = window.URL.createObjectURL(blob)
-    const link = document.createElement('a')
-
-    link.href = url
-    link.download = filename
-
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    window.URL.revokeObjectURL(url)
-  } catch (error) {
-    console.error('Download error:', error)
-  }
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
 }
 
 export const retryExport = async (id: string, signal?: AbortSignal) => {


### PR DESCRIPTION
## Portée

Cette PR évite de matérialiser les exports multi-Go dans un Blob JavaScript : le transfert est délégué au gestionnaire natif du navigateur.

**Ce changement n'est pas présenté comme la correction de la troncature autour de 1 Go.** Le même arrêt est reproduit avec curl, sans Blob ni Axios. La cause racine se situe donc dans la chaîne serveur/proxy.

## Changements

- ticket de téléchargement demandé au backend ;
- téléchargement natif, sans Blob en mémoire ;
- timeouts Nginx à 1 heure et buffering désactivé ;
- tests unitaires du déclenchement natif.

## Validation

- Vitest ciblé : 2 tests réussis ;
- ESLint ciblé : aucune erreur ;
- git diff --check : OK.

Cette PR reste complémentaire au support Range backend, mais n'est pas nécessaire pour valider le correctif réseau OPS.