### PR TITLE
feat(onboarding): pilote la disponibilité via un feature flag

### DIFF
--- a/src/components/Routes/PrivateRoute.tsx
+++ b/src/components/Routes/PrivateRoute.tsx
@@ -33,6 +33,7 @@ import { throttle } from 'lodash'
 import type React from 'react'
 import { useContext, useEffect, useState } from 'react'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import useOnboardingEnabled from 'hooks/onboarding/useOnboardingEnabled'
 import useOnboardingStatus from 'hooks/onboarding/useOnboardingStatus'
 import { updateConfigFromFhirMetadata } from 'services/aphp/serviceFhirConfig'
 import { isAccessTokenValid } from 'utils/tokens'
@@ -85,8 +86,9 @@ const PrivateRoute: React.FC = () => {
   const appConfig = useContext(AppConfig)
   const location = useLocation()
   const hasValidToken = isAccessTokenValid()
+  const onboardingEnabled = useOnboardingEnabled()
   const { status: onboardingStatus, statusPending: onboardingStatusPending } = useOnboardingStatus(
-    !!me && hasValidToken
+    !!me && hasValidToken && onboardingEnabled
   )
   const [fetchedFhirMetadata, setFetchedFhirMetadata] = useState(false)
 
@@ -162,6 +164,10 @@ const PrivateRoute: React.FC = () => {
         </DialogActions>
       </Dialog>
     )
+  } else if (!onboardingEnabled) {
+    // Feature flag off (globally, or the user's APH code is outside the restricted allow-list):
+    // the app behaves as before, no status fetch and no redirect to the journey.
+    return <Outlet />
   } else if (onboardingStatusPending) {
     // Never gate on an unconfirmed status. The status query keeps retrying in the background on
     // failure, so a returning session is never judged on the default (not-onboarded) state and an

--- a/src/components/Routes/__tests__/PrivateRoute.test.tsx
+++ b/src/components/Routes/__tests__/PrivateRoute.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockUseAppSelector, mockUseOnboardingStatus } = vi.hoisted(() => ({
+const { mockUseAppSelector, mockUseOnboardingStatus, mockUseOnboardingEnabled } = vi.hoisted(() => ({
   mockUseAppSelector: vi.fn(),
-  mockUseOnboardingStatus: vi.fn()
+  mockUseOnboardingStatus: vi.fn(),
+  mockUseOnboardingEnabled: vi.fn()
 }))
 
 vi.mock('state', () => ({
@@ -16,6 +17,10 @@ vi.mock('state', () => ({
 vi.mock('hooks/onboarding/useOnboardingStatus', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default: (...args: any[]) => mockUseOnboardingStatus(...args)
+}))
+
+vi.mock('hooks/onboarding/useOnboardingEnabled', () => ({
+  default: () => mockUseOnboardingEnabled()
 }))
 
 vi.mock('services/aphp/serviceFhirConfig', () => ({
@@ -76,6 +81,7 @@ describe('PrivateRoute', () => {
     localStorage.clear()
     setMe(null)
     setStatus(undefined, true)
+    mockUseOnboardingEnabled.mockReturnValue(true)
   })
 
   it("bloque l'accès quand me est null", () => {
@@ -129,5 +135,24 @@ describe('PrivateRoute', () => {
     setStatus(completedStatus)
     renderPrivateRoute()
     expect(mockUseOnboardingStatus).toHaveBeenCalledWith(true)
+  })
+
+  it('laisse passer sans redirection quand le feature flag est désactivé', () => {
+    setValidToken()
+    setMe({ id: 'user-1' })
+    setStatus(pendingStatus)
+    mockUseOnboardingEnabled.mockReturnValue(false)
+    renderPrivateRoute()
+    expect(screen.getByText('private content')).toBeInTheDocument()
+    expect(screen.queryByText('onboarding page')).not.toBeInTheDocument()
+  })
+
+  it('ne lit pas le statut onboarding quand le feature flag est désactivé', () => {
+    setValidToken()
+    setMe({ id: 'user-1' })
+    setStatus(completedStatus)
+    mockUseOnboardingEnabled.mockReturnValue(false)
+    renderPrivateRoute()
+    expect(mockUseOnboardingStatus).toHaveBeenCalledWith(false)
   })
 })

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -151,6 +151,9 @@ export type AppConfig = {
     maintenancePopup: FeatureConfig & {
       exceptionAphCodes: string[]
     }
+    onboarding: FeatureConfig & {
+      allowedAphCodes: string[]
+    }
   }
   core: {
     fhir: {
@@ -422,6 +425,10 @@ let config: AppConfig = {
     maintenancePopup: {
       enabled: false,
       exceptionAphCodes: []
+    },
+    onboarding: {
+      enabled: false,
+      allowedAphCodes: []
     }
   },
   system: {

--- a/src/hooks/onboarding/__tests__/useOnboardingEnabled.test.tsx
+++ b/src/hooks/onboarding/__tests__/useOnboardingEnabled.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const { mockUseAppSelector } = vi.hoisted(() => ({
+  mockUseAppSelector: vi.fn()
+}))
+
+vi.mock('state', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useAppSelector: (selector: any) => mockUseAppSelector(selector)
+}))
+
+import { AppConfig, type AppConfig as AppConfigType } from 'config'
+import useOnboardingEnabled from '../useOnboardingEnabled'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const setMe = (me: any) => mockUseAppSelector.mockImplementation((selector: any) => selector({ me }))
+
+const renderWith = (enabled: boolean, allowedAphCodes: string[]) => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AppConfig.Provider value={{ features: { onboarding: { enabled, allowedAphCodes } } } as unknown as AppConfigType}>
+      {children}
+    </AppConfig.Provider>
+  )
+  return renderHook(() => useOnboardingEnabled(), { wrapper }).result.current
+}
+
+describe('useOnboardingEnabled', () => {
+  it('reste désactivé quand le flag est off, quelle que soit la situation', () => {
+    setMe({ userName: '4163302' })
+    expect(renderWith(false, [])).toBe(false)
+    expect(renderWith(false, ['4163302'])).toBe(false)
+  })
+
+  it('est actif pour tous quand le flag est on et la liste vide', () => {
+    setMe({ userName: '4163302' })
+    expect(renderWith(true, [])).toBe(true)
+  })
+
+  it('en mode restreint, ne cible que les codes APH listés', () => {
+    setMe({ userName: '4163302' })
+    expect(renderWith(true, ['4163302', '7069721'])).toBe(true)
+    expect(renderWith(true, ['7069721'])).toBe(false)
+  })
+
+  it('reste désactivé sans code APH utilisateur', () => {
+    setMe(null)
+    expect(renderWith(true, [])).toBe(false)
+  })
+})

--- a/src/hooks/onboarding/useOnboardingEnabled.ts
+++ b/src/hooks/onboarding/useOnboardingEnabled.ts
@@ -1,0 +1,16 @@
+import { AppConfig } from 'config'
+import { useContext } from 'react'
+import { useAppSelector } from 'state'
+
+// Resolves the onboarding feature flag for the current user. An empty allow-list means the flag is
+// active for everyone; a non-empty list restricts it to the APH codes it contains. Editing the flag
+// lives in the appConfig ConfigMap, so it toggles without redeploying the application.
+const useOnboardingEnabled = () => {
+  const appConfig = useContext(AppConfig)
+  const aphCode = useAppSelector((state) => state.me?.userName)
+  const { enabled, allowedAphCodes } = appConfig.features.onboarding
+
+  return enabled && !!aphCode && (allowedAphCodes.length === 0 || allowedAphCodes.includes(aphCode))
+}
+
+export default useOnboardingEnabled

--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -2,6 +2,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { Avatar, Box, Button, Typography } from '@mui/material'
 import logo from 'assets/images/logo-login.png'
+import useOnboardingEnabled from 'hooks/onboarding/useOnboardingEnabled'
 import useOnboardingStatus from 'hooks/onboarding/useOnboardingStatus'
 import React from 'react'
 import { Navigate } from 'react-router-dom'
@@ -86,7 +87,12 @@ const OnboardingLayout = () => {
 }
 
 const Onboarding = () => {
-  const { status } = useOnboardingStatus()
+  const onboardingEnabled = useOnboardingEnabled()
+  const { status } = useOnboardingStatus(onboardingEnabled)
+
+  if (!onboardingEnabled) {
+    return <Navigate to="/home" replace />
+  }
 
   if (status?.onboarding_completed_at != null) {
     return <Navigate to="/home" replace />

--- a/src/views/Onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/Onboarding/__tests__/Onboarding.test.tsx
@@ -7,14 +7,19 @@ import { Provider } from 'react-redux'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { updateStep, signCharter, getStatus } = vi.hoisted(() => ({
+const { updateStep, signCharter, getStatus, mockUseOnboardingEnabled } = vi.hoisted(() => ({
   updateStep: vi.fn(),
   signCharter: vi.fn(),
-  getStatus: vi.fn()
+  getStatus: vi.fn(),
+  mockUseOnboardingEnabled: vi.fn()
 }))
 
 vi.mock('services/aphp/serviceOnboarding', () => ({
   default: { updateStep, signCharter, getStatus }
+}))
+
+vi.mock('hooks/onboarding/useOnboardingEnabled', () => ({
+  default: () => mockUseOnboardingEnabled()
 }))
 
 import { ONBOARDING_STATUS_QUERY_KEY } from 'hooks/onboarding/useOnboardingStatus'
@@ -53,6 +58,13 @@ describe('Onboarding page', () => {
     signCharter.mockReset()
     getStatus.mockReset()
     updateStep.mockResolvedValue({ onboarding_step: 3, onboarding_completed_at: null })
+    mockUseOnboardingEnabled.mockReturnValue(true)
+  })
+
+  it('redirects to /home when the feature flag is disabled', () => {
+    mockUseOnboardingEnabled.mockReturnValue(false)
+    renderAt(baseStatus)
+    expect(screen.getByText('home page')).toBeInTheDocument()
   })
 
   it('redirects to /home when the journey is already completed', () => {


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3383

Piloter la disponibilité de l'onboarding en production via un feature flag : dark launch, activation restreinte par code APH, kill switch.

Related to MR : https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/ops/-/merge_requests/99

## Changements réalisés
Ajout de `features.onboarding` (`enabled`, `allowedAphCodes`) dans la config. Le hook `useOnboardingEnabled` résout le flag pour l'utilisateur courant : off, actif pour tous si la liste est vide, restreint aux codes APH listés sinon. `PrivateRoute` ne redirige et ne lit le statut que si le flag est actif ; la vue `Onboarding` renvoie vers `/home` quand il est off. Le flag vit dans l'appConfig (ConfigMap), modifiable sans redéploiement.

## Impacts
Front. Défaut `enabled: false` : l'onboarding est éteint tant qu'il n'est pas activé côté config.

## Tests réalisés
Unitaires.

## Risques
RAS.
