### PR TITLE
feat(onboarding): active la liste APH indépendamment du flag global

### DIFF
--- a/src/hooks/onboarding/__tests__/useOnboardingEnabled.test.tsx
+++ b/src/hooks/onboarding/__tests__/useOnboardingEnabled.test.tsx
@@ -27,25 +27,25 @@ const renderWith = (enabled: boolean, allowedAphCodes: string[]) => {
 }
 
 describe('useOnboardingEnabled', () => {
-  it('reste désactivé quand le flag est off, quelle que soit la situation', () => {
+  it('reste désactivé pour tous par défaut (flag off, liste vide)', () => {
     setMe({ userName: '4163302' })
     expect(renderWith(false, [])).toBe(false)
-    expect(renderWith(false, ['4163302'])).toBe(false)
   })
 
-  it('est actif pour tous quand le flag est on et la liste vide', () => {
+  it('est actif pour tous quand le flag est on, sans regarder la liste', () => {
     setMe({ userName: '4163302' })
     expect(renderWith(true, [])).toBe(true)
+    expect(renderWith(true, ['7069721'])).toBe(true)
   })
 
-  it('en mode restreint, ne cible que les codes APH listés', () => {
+  it('active les codes APH listés même quand le flag global est off', () => {
     setMe({ userName: '4163302' })
-    expect(renderWith(true, ['4163302', '7069721'])).toBe(true)
-    expect(renderWith(true, ['7069721'])).toBe(false)
+    expect(renderWith(false, ['4163302', '7069721'])).toBe(true)
+    expect(renderWith(false, ['7069721'])).toBe(false)
   })
 
-  it('reste désactivé sans code APH utilisateur', () => {
+  it('reste désactivé sans code APH utilisateur quand seule la liste pilote', () => {
     setMe(null)
-    expect(renderWith(true, [])).toBe(false)
+    expect(renderWith(false, ['4163302'])).toBe(false)
   })
 })

--- a/src/hooks/onboarding/useOnboardingEnabled.ts
+++ b/src/hooks/onboarding/useOnboardingEnabled.ts
@@ -2,15 +2,16 @@ import { AppConfig } from 'config'
 import { useContext } from 'react'
 import { useAppSelector } from 'state'
 
-// Resolves the onboarding feature flag for the current user. An empty allow-list means the flag is
-// active for everyone; a non-empty list restricts it to the APH codes it contains. Editing the flag
-// lives in the appConfig ConfigMap, so it toggles without redeploying the application.
+// Resolves the onboarding feature flag for the current user. `enabled` turns the journey on for
+// everyone; `allowedAphCodes` turns it on for the listed APH codes regardless of `enabled`, so a
+// pilot runs with `enabled: false` and a filled list. Off for everyone is `enabled: false` with an
+// empty list. The flag lives in the appConfig ConfigMap, so it toggles without redeploying the app.
 const useOnboardingEnabled = () => {
   const appConfig = useContext(AppConfig)
   const aphCode = useAppSelector((state) => state.me?.userName)
   const { enabled, allowedAphCodes } = appConfig.features.onboarding
 
-  return enabled && !!aphCode && (allowedAphCodes.length === 0 || allowedAphCodes.includes(aphCode))
+  return enabled || (!!aphCode && allowedAphCodes.includes(aphCode))
 }
 
 export default useOnboardingEnabled


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3383

Suite de #1306 : la liste de codes APH doit activer l'onboarding indépendamment du flag global.

## Changements réalisés
`useOnboardingEnabled` passe à `enabled || (aph ∈ allowedAphCodes)`. `enabled` active pour tous ; `allowedAphCodes` cible des codes précis même avec `enabled: false` ; off pour tous = `enabled: false` et liste vide.

## Impacts
Front.

## Tests réalisés
Tests du hook mis à jour pour la sémantique découplée.

## Risques
`enabled: false` n'est plus un kill switch absolu tant que la liste n'est pas vidée.
