### PR TITLE
feat(onboarding): intègre les derniers correctifs frigo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -8,21 +8,33 @@
     <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&family=Open+Sans:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&family=Open+Sans:wght@400;600;700&family=Rubik:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-    <link rel="stylesheet" href="/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+    <link
+      rel="stylesheet"
+      href="/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
     <script type="text/javascript">
-      var undefinedClarityAppId = "{" + "VITE_CLARITY_APP_ID" + "}"
-      var clarityAppId = "{VITE_CLARITY_APP_ID}"
-      if (clarityAppId !== "" && clarityAppId !== undefinedClarityAppId) {
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", clarityAppId);
+      var undefinedClarityAppId = '{' + 'VITE_CLARITY_APP_ID' + '}'
+      var clarityAppId = '{VITE_CLARITY_APP_ID}'
+      if (clarityAppId !== '' && clarityAppId !== undefinedClarityAppId) {
+        ;(function (c, l, a, r, i, t, y) {
+          c[a] =
+            c[a] ||
+            function () {
+              ;(c[a].q = c[a].q || []).push(arguments)
+            }
+          t = l.createElement(r)
+          t.async = 1
+          t.src = 'https://www.clarity.ms/tag/' + i
+          y = l.getElementsByTagName(r)[0]
+          y.parentNode.insertBefore(t, y)
+        })(window, document, 'clarity', 'script', clarityAppId)
       }
     </script>
     <!--
@@ -44,7 +56,7 @@
       #root:not(:empty) + #app-loader {
         display: none;
       }
-      
+
       #app-loader {
         position: fixed;
         top: 0;
@@ -65,7 +77,7 @@
         border-radius: 50%;
         width: 96px;
         height: 96px;
-        color: #ED6D91;
+        color: #ed6d91;
       }
       .loader:before,
       .loader:after {
@@ -81,9 +93,9 @@
         animation: 1s spin linear infinite;
       }
       .loader:after {
-        color: #0063AF;
+        color: #0063af;
         transform: rotateY(70deg);
-        animation-delay: .4s;
+        animation-delay: 0.4s;
       }
 
       @keyframes rotate {
@@ -107,44 +119,42 @@
       @keyframes spin {
         0%,
         100% {
-          box-shadow: .2em 0px 0 0px currentcolor;
+          box-shadow: 0.2em 0px 0 0px currentcolor;
         }
         12% {
-          box-shadow: .2em .2em 0 0 currentcolor;
+          box-shadow: 0.2em 0.2em 0 0 currentcolor;
         }
         25% {
-          box-shadow: 0 .2em 0 0px currentcolor;
+          box-shadow: 0 0.2em 0 0px currentcolor;
         }
         37% {
-          box-shadow: -.2em .2em 0 0 currentcolor;
+          box-shadow: -0.2em 0.2em 0 0 currentcolor;
         }
         50% {
-          box-shadow: -.2em 0 0 0 currentcolor;
+          box-shadow: -0.2em 0 0 0 currentcolor;
         }
         62% {
-          box-shadow: -.2em -.2em 0 0 currentcolor;
+          box-shadow: -0.2em -0.2em 0 0 currentcolor;
         }
         75% {
-          box-shadow: 0px -.2em 0 0 currentcolor;
+          box-shadow: 0px -0.2em 0 0 currentcolor;
         }
         87% {
-          box-shadow: .2em -.2em 0 0 currentcolor;
+          box-shadow: 0.2em -0.2em 0 0 currentcolor;
         }
       }
-    
     </style>
   </head>
 
   <body style="margin: 0px">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    
+
     <div id="app-loader">
-      <div style="margin-bottom: 3em; margin-top: -10%;">
+      <div style="margin-bottom: 3em; margin-top: -10%">
         <img src="/logo_c360_small.png" alt="Cohort360" />
       </div>
-      <div class="loader">
-      </div>
+      <div class="loader"></div>
     </div>
     <!--
       This HTML file is a template.

--- a/src/components/ui/InfoBadge/index.tsx
+++ b/src/components/ui/InfoBadge/index.tsx
@@ -1,11 +1,13 @@
 import { styled, useTheme } from '@mui/material'
 import React from 'react'
 
-import CircleBadge from 'components/ui/CircleBadge'
+import CircleBadge, { type CircleBadgeVariant } from 'components/ui/CircleBadge'
 
 type InfoBadgeProps = {
   size?: number
   className?: string
+  color?: string
+  variant?: CircleBadgeVariant
 }
 
 const Glyph = styled('span')({
@@ -13,11 +15,11 @@ const Glyph = styled('span')({
   fontStyle: 'italic'
 })
 
-const InfoBadge = ({ size = 24, className }: InfoBadgeProps) => {
+const InfoBadge = ({ size = 24, className, color, variant = 'outlined' }: InfoBadgeProps) => {
   const theme = useTheme()
 
   return (
-    <CircleBadge color={theme.palette.primary.dark} variant="outlined" size={size} className={className}>
+    <CircleBadge color={color ?? theme.palette.primary.dark} variant={variant} size={size} className={className}>
       <Glyph>i</Glyph>
     </CircleBadge>
   )

--- a/src/hooks/onboarding/__tests__/useOnboardingEnabled.test.tsx
+++ b/src/hooks/onboarding/__tests__/useOnboardingEnabled.test.tsx
@@ -27,25 +27,25 @@ const renderWith = (enabled: boolean, allowedAphCodes: string[]) => {
 }
 
 describe('useOnboardingEnabled', () => {
-  it('reste désactivé quand le flag est off, quelle que soit la situation', () => {
+  it('reste désactivé pour tous par défaut (flag off, liste vide)', () => {
     setMe({ userName: '4163302' })
     expect(renderWith(false, [])).toBe(false)
-    expect(renderWith(false, ['4163302'])).toBe(false)
   })
 
-  it('est actif pour tous quand le flag est on et la liste vide', () => {
+  it('est actif pour tous quand le flag est on, sans regarder la liste', () => {
     setMe({ userName: '4163302' })
     expect(renderWith(true, [])).toBe(true)
+    expect(renderWith(true, ['7069721'])).toBe(true)
   })
 
-  it('en mode restreint, ne cible que les codes APH listés', () => {
+  it('active les codes APH listés même quand le flag global est off', () => {
     setMe({ userName: '4163302' })
-    expect(renderWith(true, ['4163302', '7069721'])).toBe(true)
-    expect(renderWith(true, ['7069721'])).toBe(false)
+    expect(renderWith(false, ['4163302', '7069721'])).toBe(true)
+    expect(renderWith(false, ['7069721'])).toBe(false)
   })
 
-  it('reste désactivé sans code APH utilisateur', () => {
+  it('reste désactivé sans code APH utilisateur quand seule la liste pilote', () => {
     setMe(null)
-    expect(renderWith(true, [])).toBe(false)
+    expect(renderWith(false, ['4163302'])).toBe(false)
   })
 })

--- a/src/hooks/onboarding/useOnboardingEnabled.ts
+++ b/src/hooks/onboarding/useOnboardingEnabled.ts
@@ -2,15 +2,16 @@ import { AppConfig } from 'config'
 import { useContext } from 'react'
 import { useAppSelector } from 'state'
 
-// Resolves the onboarding feature flag for the current user. An empty allow-list means the flag is
-// active for everyone; a non-empty list restricts it to the APH codes it contains. Editing the flag
-// lives in the appConfig ConfigMap, so it toggles without redeploying the application.
+// Resolves the onboarding feature flag for the current user. `enabled` turns the journey on for
+// everyone; `allowedAphCodes` turns it on for the listed APH codes regardless of `enabled`, so a
+// pilot runs with `enabled: false` and a filled list. Off for everyone is `enabled: false` with an
+// empty list. The flag lives in the appConfig ConfigMap, so it toggles without redeploying the app.
 const useOnboardingEnabled = () => {
   const appConfig = useContext(AppConfig)
   const aphCode = useAppSelector((state) => state.me?.userName)
   const { enabled, allowedAphCodes } = appConfig.features.onboarding
 
-  return enabled && !!aphCode && (allowedAphCodes.length === 0 || allowedAphCodes.includes(aphCode))
+  return enabled || (!!aphCode && allowedAphCodes.includes(aphCode))
 }
 
 export default useOnboardingEnabled

--- a/src/services/aphp/__tests__/serviceOnboarding.test.ts
+++ b/src/services/aphp/__tests__/serviceOnboarding.test.ts
@@ -56,6 +56,16 @@ describe('serviceOnboarding', () => {
     expect(get).toHaveBeenCalledWith('accesses/rights/')
   })
 
+  it('rejects when the accesses request is swallowed by the interceptor', async () => {
+    get.mockResolvedValue(new Error('Request failed with status code 503'))
+    await expect(serviceOnboarding.getMyAccesses()).rejects.toThrow()
+  })
+
+  it('rejects when the rights catalog request is swallowed by the interceptor', async () => {
+    get.mockResolvedValue(new Error('Request failed with status code 503'))
+    await expect(serviceOnboarding.getRightsCatalog()).rejects.toThrow()
+  })
+
   it('returns the current onboarding status', async () => {
     get.mockResolvedValue({
       data: { onboarding_step: 3, onboarding_completed_at: '2026-06-29T10:00:00Z', charter_signed_at: null }

--- a/src/services/aphp/serviceOnboarding.ts
+++ b/src/services/aphp/serviceOnboarding.ts
@@ -39,14 +39,8 @@ const serviceOnboarding: IServiceOnboarding = {
   updateStep: async (step) =>
     requireData(await apiBackend.patch<OnboardingProgress>('/users/me/onboarding/', { onboarding_step: step })),
   signCharter: async () => requireData(await apiBackend.post<CharterSignature>('/users/me/onboarding/charter/')),
-  getMyAccesses: async () => {
-    const { data } = await apiBackend.get<MyAccess[]>('accesses/accesses/my-accesses/')
-    return data
-  },
-  getRightsCatalog: async () => {
-    const { data } = await apiBackend.get<RightCatalogCategory[]>('accesses/rights/')
-    return data
-  },
+  getMyAccesses: async () => requireData(await apiBackend.get<MyAccess[]>('accesses/accesses/my-accesses/')),
+  getRightsCatalog: async () => requireData(await apiBackend.get<RightCatalogCategory[]>('accesses/rights/')),
   getStatus: async () => requireData(await apiBackend.get<OnboardingStatus>('/users/me/onboarding/'))
 }
 

--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -61,7 +61,13 @@ const OnboardingLayout = () => {
           Revenir
         </Button>
       )}
-      <Button variant="contained" onClick={goNext} disabled={saving} endIcon={<ArrowForwardIcon />}>
+      <Button
+        className={classes.nextButton}
+        variant="contained"
+        onClick={goNext}
+        disabled={saving}
+        endIcon={<ArrowForwardIcon />}
+      >
         {primaryLabel}
       </Button>
     </>

--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -1,36 +1,24 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import { Avatar, Box, Button, Typography } from '@mui/material'
+import { Button, Typography } from '@mui/material'
 import logo from 'assets/images/logo-login.png'
 import useOnboardingEnabled from 'hooks/onboarding/useOnboardingEnabled'
 import useOnboardingStatus from 'hooks/onboarding/useOnboardingStatus'
 import React from 'react'
 import { Navigate } from 'react-router-dom'
-import { useAppSelector } from 'state'
 
 import { OnboardingProvider, useOnboarding } from './OnboardingContext'
 import { ONBOARDING_STEPS } from './steps'
 import useStyles from './styles'
+import UserMenu from './UserMenu'
 import WelcomeScreen from './WelcomeScreen'
 import WizardShell from './WizardShell'
 
 const PROGRESS_ERROR_MESSAGE =
   "Une erreur est survenue lors de l'enregistrement de votre progression. Veuillez réessayer."
 
-const getInitials = (name?: string) =>
-  name
-    ? name
-        .trim()
-        .split(/\s+/)
-        .map((word) => word[0])
-        .slice(0, 2)
-        .join('')
-        .toUpperCase()
-    : ''
-
 const OnboardingLayout = () => {
   const { classes } = useStyles()
-  const displayName = useAppSelector((state) => state.me?.displayName)
   const { screen, currentStep, screenConfig, stepProgress, primaryLabel, saving, error, goNext, goBack } =
     useOnboarding()
 
@@ -39,12 +27,7 @@ const OnboardingLayout = () => {
   const header = (
     <>
       <img className={classes.logo} src={logo} alt="Logo Cohort360" />
-      {displayName && (
-        <Box className={classes.userBox}>
-          <Avatar className={classes.avatar}>{getInitials(displayName)}</Avatar>
-          <Typography className={classes.user}>{displayName}</Typography>
-        </Box>
-      )}
+      <UserMenu />
     </>
   )
 

--- a/src/views/Onboarding/UserMenu.tsx
+++ b/src/views/Onboarding/UserMenu.tsx
@@ -1,0 +1,63 @@
+import { Avatar, ButtonBase, Menu, MenuItem, Typography } from '@mui/material'
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useAppDispatch, useAppSelector } from 'state'
+import { logout } from 'state/me'
+
+import useStyles from './styles'
+
+const getInitials = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+
+const UserMenu = () => {
+  const { classes } = useStyles()
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+  const displayName = useAppSelector((state) => state.me?.displayName)
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+
+  if (!displayName) {
+    return null
+  }
+
+  const onLogout = () => {
+    setAnchorEl(null)
+    dispatch(logout())
+    navigate('/')
+  }
+
+  return (
+    <>
+      <ButtonBase
+        className={classes.userBox}
+        aria-haspopup="menu"
+        aria-expanded={anchorEl !== null}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+      >
+        <Avatar className={classes.avatar}>{getInitials(displayName)}</Avatar>
+        <Typography className={classes.user}>{displayName}</Typography>
+      </ButtonBase>
+      <Menu
+        anchorEl={anchorEl}
+        open={anchorEl !== null}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { className: classes.userMenu } }}
+      >
+        <MenuItem className={classes.userMenuItem} onClick={onLogout}>
+          Se déconnecter
+        </MenuItem>
+      </Menu>
+    </>
+  )
+}
+
+export default UserMenu

--- a/src/views/Onboarding/UserMenu.tsx
+++ b/src/views/Onboarding/UserMenu.tsx
@@ -27,10 +27,10 @@ const UserMenu = () => {
     return null
   }
 
-  const onLogout = () => {
+  const onLogout = async () => {
     setAnchorEl(null)
-    dispatch(logout())
-    navigate('/')
+    await dispatch(logout())
+    navigate('/', { replace: true })
   }
 
   return (

--- a/src/views/Onboarding/__tests__/UserMenu.test.tsx
+++ b/src/views/Onboarding/__tests__/UserMenu.test.tsx
@@ -57,6 +57,30 @@ describe('UserMenu (US-3384)', () => {
     expect(screen.getByText('login page')).toBeInTheDocument()
   })
 
+  it('redirects to the login page only once the logout has completed (RG3384.02)', async () => {
+    let resolveLogout: () => void = () => undefined
+    practitionerLogout.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = () => resolve()
+        })
+    )
+    const user = userEvent.setup()
+    const store = renderUserMenu()
+
+    await user.click(screen.getByRole('button', { name: /Cesar RICHARD/ }))
+    await user.click(screen.getByRole('menuitem', { name: 'Se déconnecter' }))
+
+    await waitFor(() => expect(practitionerLogout).toHaveBeenCalled())
+    expect(screen.queryByText('login page')).not.toBeInTheDocument()
+    expect(store.getState().me).not.toBeNull()
+
+    resolveLogout()
+
+    await waitFor(() => expect(store.getState().me).toBeNull())
+    expect(screen.getByText('login page')).toBeInTheDocument()
+  })
+
   it('renders nothing when no user is connected', () => {
     renderUserMenu(null)
     expect(screen.queryByRole('button')).not.toBeInTheDocument()

--- a/src/views/Onboarding/__tests__/UserMenu.test.tsx
+++ b/src/views/Onboarding/__tests__/UserMenu.test.tsx
@@ -1,0 +1,64 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { practitionerLogout } = vi.hoisted(() => ({ practitionerLogout: vi.fn() }))
+
+vi.mock('services/aphp', () => ({
+  default: { practitioner: { logout: practitionerLogout } }
+}))
+
+import meReducer, { type MeState } from 'state/me'
+import UserMenu from '../UserMenu'
+
+const renderUserMenu = (me: MeState = { displayName: 'Cesar RICHARD' } as MeState) => {
+  const store = configureStore({ reducer: { me: meReducer }, preloadedState: { me } })
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/onboarding']}>
+        <Routes>
+          <Route path="/onboarding" element={<UserMenu />} />
+          <Route path="/" element={<div>login page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  )
+  return store
+}
+
+describe('UserMenu (US-3384)', () => {
+  beforeEach(() => {
+    practitionerLogout.mockReset()
+    practitionerLogout.mockResolvedValue(undefined)
+  })
+
+  it('opens the logout action on a click on the user name (RG3384.01)', async () => {
+    const user = userEvent.setup()
+    renderUserMenu()
+
+    expect(screen.queryByRole('menuitem', { name: 'Se déconnecter' })).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /Cesar RICHARD/ }))
+    expect(screen.getByRole('menuitem', { name: 'Se déconnecter' })).toBeInTheDocument()
+  })
+
+  it('ends the session and goes back to the login page (RG3384.02)', async () => {
+    const user = userEvent.setup()
+    const store = renderUserMenu()
+
+    await user.click(screen.getByRole('button', { name: /Cesar RICHARD/ }))
+    await user.click(screen.getByRole('menuitem', { name: 'Se déconnecter' }))
+
+    await waitFor(() => expect(practitionerLogout).toHaveBeenCalled())
+    await waitFor(() => expect(store.getState().me).toBeNull())
+    expect(screen.getByText('login page')).toBeInTheDocument()
+  })
+
+  it('renders nothing when no user is connected', () => {
+    renderUserMenu(null)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})

--- a/src/views/Onboarding/__tests__/steps.test.ts
+++ b/src/views/Onboarding/__tests__/steps.test.ts
@@ -33,8 +33,8 @@ describe('onboarding step 2 configuration', () => {
     expect(withAction[0].primaryAction?.label).toBe('Signer')
   })
 
-  it('renders the charter without the card wrapper', () => {
-    expect(getScreenConfig(COMMITMENTS_STEP, 7)?.layout).toBe('bare')
+  it('renders the charter inside the default card wrapper', () => {
+    expect(getScreenConfig(COMMITMENTS_STEP, 7)?.layout).toBeUndefined()
   })
 
   it('counts a screenless step as a single slot so the journey never stalls', () => {

--- a/src/views/Onboarding/screens/commitments/CharterSignature.tsx
+++ b/src/views/Onboarding/screens/commitments/CharterSignature.tsx
@@ -11,7 +11,7 @@ const CharterSignature = () => {
 
   return (
     <Box>
-      <Typography variant="h3" className={classes.bareTitle}>
+      <Typography variant="h4" className={classes.title}>
         Signer la charte d'engagement
       </Typography>
       <Box className={classes.documentViewer}>
@@ -28,6 +28,11 @@ const CharterSignature = () => {
             </Link>
           </Box>
         </object>
+      </Box>
+      <Box className={classes.linkRow}>
+        <Link className={classes.link} href={CHARTER_PDF_URL} download>
+          Télécharger une copie de la charte d'engagement
+        </Link>
       </Box>
     </Box>
   )

--- a/src/views/Onboarding/screens/commitments/UsagePurposes.tsx
+++ b/src/views/Onboarding/screens/commitments/UsagePurposes.tsx
@@ -30,7 +30,7 @@ const UsagePurposes = () => {
       <Typography className={classes.sectionText}>
         L'Entrepôt de Données de Santé (EDS) de l'AP-HP contient des données à caractère personnel sensibles.
       </Typography>
-      <Typography className={classes.subTitle}>
+      <Typography className={classes.sectionLead}>
         Seules certaines finalités d'utilisation des données sont autorisées :
       </Typography>
       {PURPOSES.map(({ label, icon: Icon }) => (
@@ -38,7 +38,7 @@ const UsagePurposes = () => {
           <Box className={classes.iconBox}>
             <Icon fontSize="small" />
           </Box>
-          <Typography className={classes.stepTitle}>{label}</Typography>
+          <Typography className={classes.rowLabel}>{label}</Typography>
         </Box>
       ))}
     </Box>

--- a/src/views/Onboarding/screens/environment/UserRights.tsx
+++ b/src/views/Onboarding/screens/environment/UserRights.tsx
@@ -1,5 +1,5 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import { Box, CircularProgress, Typography } from '@mui/material'
+import { Box, CircularProgress, Link, Typography } from '@mui/material'
 import moment from 'moment'
 import React from 'react'
 
@@ -7,6 +7,8 @@ import { useAppSelector } from 'state'
 
 import useStyles from '../../styles'
 import { useUserAccesses } from './useUserAccesses'
+
+const SUPPORT_MAIL = 'id.recherche.support.dsn@aphp.fr'
 
 const UserRights = () => {
   const { classes } = useStyles()
@@ -30,12 +32,20 @@ const UserRights = () => {
     )
   }
 
-  if (hasError) {
+  // Un appel en échec comme un périmètre vide laissent l'écran sans rien à montrer : même message,
+  // et le parcours reste franchissable.
+  if (hasError || accesses.length === 0) {
     return (
       <Box>
         {title}
-        <Typography role="alert" className={classes.error}>
-          Une erreur est survenue lors de la récupération de vos droits d'accès. Veuillez réessayer ultérieurement.
+        <Typography role="status" className={classes.sectionText}>
+          Le détail de votre accès à Cohort360 n'est pas disponible pour le moment.
+        </Typography>
+        <Typography className={classes.sectionText}>
+          Pour en savoir plus sur vos droits et votre périmètre accessible dans l'application, contactez le support :{' '}
+          <Link className={classes.inlineLink} href={`mailto:${SUPPORT_MAIL}`}>
+            {SUPPORT_MAIL}
+          </Link>
         </Typography>
       </Box>
     )

--- a/src/views/Onboarding/screens/environment/WhatIsEds.tsx
+++ b/src/views/Onboarding/screens/environment/WhatIsEds.tsx
@@ -9,6 +9,7 @@ import type { SvgIconProps } from '@mui/material'
 import InfoBadge from 'components/ui/InfoBadge'
 import type { ComponentType } from 'react'
 import React from 'react'
+import { eds } from 'styles/palette'
 
 import useStyles from '../../styles'
 
@@ -83,7 +84,7 @@ const WhatIsEds = () => {
 
       <Divider className={classes.divider} />
       <Box className={classes.infoRow}>
-        <InfoBadge className={classes.infoBadge} />
+        <InfoBadge className={classes.infoBadge} variant="filled" color={eds.blue[600]} />
         <Typography className={classes.infoText}>
           Selon votre profil d'habilitation, vous accédez à des données nominatives (identité des patients visible) ou
           pseudonymisées (identité masquée).

--- a/src/views/Onboarding/screens/environment/__tests__/UserRights.test.tsx
+++ b/src/views/Onboarding/screens/environment/__tests__/UserRights.test.tsx
@@ -110,9 +110,29 @@ describe('UserRights (US-3307)', () => {
     expect(await screen.findByText('Non renseignée')).toBeInTheDocument()
   })
 
-  it('shows an error message when a call fails', async () => {
+  it('tells the user his access details are unavailable when a call fails (RG3381.01)', async () => {
     getRightsCatalog.mockRejectedValue(new Error('boom'))
     renderUserRights()
-    expect(await screen.findByRole('alert')).toHaveTextContent(/Une erreur est survenue/)
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /Le détail de votre accès à Cohort360 n'est pas disponible/
+    )
+  })
+
+  it('points to the support without blocking the journey (RG3381.02)', async () => {
+    getMyAccesses.mockRejectedValue(new Error('boom'))
+    renderUserRights()
+    await screen.findByRole('status')
+    expect(screen.getByRole('link', { name: 'id.recherche.support.dsn@aphp.fr' })).toHaveAttribute(
+      'href',
+      'mailto:id.recherche.support.dsn@aphp.fr'
+    )
+  })
+
+  it('shows the same message when the API answers without any access', async () => {
+    getMyAccesses.mockResolvedValue([])
+    renderUserRights()
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /Le détail de votre accès à Cohort360 n'est pas disponible/
+    )
   })
 })

--- a/src/views/Onboarding/steps.ts
+++ b/src/views/Onboarding/steps.ts
@@ -83,7 +83,6 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
       {
         key: 'charter-signature',
         component: CharterSignature,
-        layout: 'bare',
         primaryAction: {
           label: 'Signer',
           run: ({ signCharter }) => signCharter(),

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -1,14 +1,21 @@
 import type { Theme } from '@mui/material/styles'
+import { eds } from 'styles/palette'
 import { makeStyles } from 'tss-react/mui'
 
 import { onboardingTokens as T } from './tokens'
+
+const FONT = "'Rubik', sans-serif"
 
 const useStyles = makeStyles()((theme: Theme) => ({
   page: {
     minHeight: '100vh',
     display: 'flex',
     flexDirection: 'column',
-    backgroundColor: T.pageBg
+    backgroundColor: T.pageBg,
+    fontFamily: FONT,
+    '& .MuiTypography-root, & .MuiButton-root': {
+      fontFamily: FONT
+    }
   },
   header: {
     display: 'flex',
@@ -93,7 +100,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
     width: 28,
     height: 28,
     borderRadius: '50%',
-    border: `2px solid ${T.railTodo}`,
     backgroundColor: T.surface,
     color: T.railDone,
     display: 'flex',
@@ -103,12 +109,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
     fontWeight: 700
   },
   stepCircleActive: {
-    border: 'none',
     backgroundColor: T.railDone,
     color: T.surface
   },
   stepCircleCompleted: {
-    border: 'none',
     color: T.railDone
   },
   stepLabel: {
@@ -143,9 +147,19 @@ const useStyles = makeStyles()((theme: Theme) => ({
   backButton: {
     // Pushed to the opposite edge from the primary action, which stays right-aligned when alone.
     marginRight: 'auto',
+    color: eds.blue[400],
+    borderColor: eds.blue[400],
     backgroundColor: T.surface,
     '&:hover': {
+      borderColor: eds.blue[400],
       backgroundColor: T.surface
+    }
+  },
+  nextButton: {
+    backgroundColor: eds.blue[400],
+    color: T.surface,
+    '&:hover': {
+      backgroundColor: eds.blue[600]
     }
   },
   title: {
@@ -154,11 +168,12 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   intro: {
     color: T.muted,
+    fontSize: 16,
     marginTop: theme.spacing(2)
   },
   stepRow: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: theme.spacing(2),
     marginTop: theme.spacing(3)
   },
@@ -175,27 +190,42 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   stepTitle: {
     color: T.ink,
+    fontSize: 16,
     fontWeight: 700
   },
   stepDesc: {
-    color: T.muted
+    color: T.muted,
+    fontSize: 16
   },
   error: {
     marginTop: theme.spacing(2),
     color: theme.palette.error.main
   },
   sectionText: {
-    color: T.muted,
+    color: T.ink,
+    fontSize: 16,
     marginTop: theme.spacing(2),
     lineHeight: 1.6
   },
   subTitle: {
     color: T.ink,
+    fontSize: 22,
     fontWeight: 700,
     marginTop: theme.spacing(3)
   },
+  sectionLead: {
+    color: T.ink,
+    fontSize: 16,
+    fontWeight: 700,
+    marginTop: theme.spacing(3)
+  },
+  rowLabel: {
+    color: T.ink,
+    fontSize: 16
+  },
   list: {
-    color: T.muted,
+    color: T.ink,
+    fontSize: 16,
     marginTop: theme.spacing(1.5),
     paddingLeft: theme.spacing(3),
     lineHeight: 1.6,
@@ -207,7 +237,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
     display: 'inline-flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
-    color: theme.palette.primary.main,
+    color: eds.blue[400],
+    fontSize: 16,
     fontWeight: 600,
     textDecoration: 'none',
     '&:hover': {
@@ -221,19 +252,21 @@ const useStyles = makeStyles()((theme: Theme) => ({
     marginTop: theme.spacing(2)
   },
   divider: {
-    marginTop: theme.spacing(3)
+    marginTop: theme.spacing(3),
+    borderColor: eds.blue[200]
   },
   infoRow: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: theme.spacing(1.5),
     marginTop: theme.spacing(3)
   },
   infoBadge: {
-    marginTop: theme.spacing(0.25)
+    flexShrink: 0
   },
   infoText: {
-    color: theme.palette.primary.main,
+    color: eds.blue[800],
+    fontSize: 16,
     lineHeight: 1.6
   },
   loadingRow: {
@@ -279,22 +312,17 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   warningNotice: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: theme.spacing(1.5),
     marginTop: theme.spacing(3)
   },
   warningBadge: {
-    marginTop: theme.spacing(-0.25)
+    flexShrink: 0
   },
   warningText: {
     color: T.warning,
     fontWeight: 600,
     lineHeight: 1.5
-  },
-  bareTitle: {
-    color: T.deepBlue,
-    fontWeight: 700,
-    marginBottom: theme.spacing(4)
   },
   illustrationRow: {
     display: 'flex',

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -259,6 +259,11 @@ const useStyles = makeStyles()((theme: Theme) => ({
       textDecoration: 'underline'
     }
   },
+  inlineLink: {
+    color: eds.blue[400],
+    fontWeight: 600,
+    textDecoration: 'underline'
+  },
   linkIcon: {
     fontSize: 16
   },

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -30,7 +30,21 @@ const useStyles = makeStyles()((theme: Theme) => ({
   userBox: {
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1.5)
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(0.5, 1),
+    borderRadius: 6,
+    '&:hover': {
+      backgroundColor: eds.blue[50]
+    }
+  },
+  userMenu: {
+    marginTop: theme.spacing(1),
+    borderRadius: 6
+  },
+  userMenuItem: {
+    fontFamily: FONT,
+    color: T.ink,
+    padding: theme.spacing(1.5, 3)
   },
   avatar: {
     width: 36,

--- a/src/views/Onboarding/tokens.ts
+++ b/src/views/Onboarding/tokens.ts
@@ -1,20 +1,20 @@
-import { eds } from 'styles/palette'
+import { aphp, eds, neutre } from 'styles/palette'
 
 export const onboardingTokens = {
-  ink: '#1F2A37',
-  muted: '#5B6472',
+  ink: neutre[800],
+  muted: neutre[600],
   pageBg: eds.blue[50],
   surface: '#FFFFFF',
   cardBorder: eds.blue[200],
-  stepIconBg: '#FBE7D5',
-  stepIconFg: '#C77B3B',
+  stepIconBg: '#FDDDBF',
+  stepIconFg: aphp.jaune[900],
   avatarBg: '#5BC5F2',
   tileBg: '#F5F8FE',
   warning: '#E5007D',
   deepBlue: '#0062AB',
   documentBg: '#7F7F7F',
-  // Rail: the travelled part is deep blue, what remains is a pale tint of it.
-  railDone: '#1D4F9B',
-  railTodo: '#A9C4EA',
-  railInactiveFg: '#5B6472'
+  // Rail: the travelled part is the dark blue, what remains is the pale blue.
+  railDone: eds.blue[400],
+  railTodo: eds.blue[200],
+  railInactiveFg: neutre[600]
 } as const


### PR DESCRIPTION
## Objectif

Intégrer dans `develop` les derniers correctifs onboarding mergés dans `frontend-frigo` après la PR #1307, sans réintroduire l'historique divergent de la branche frigo.

## Contenu

- reprend le correctif de la PR #1311 : activation de la liste APH indépendamment du feature flag global ;
- reprend les correctifs de la PR #1304 : alignement UI, menu de déconnexion, gestion de l'indisponibilité des droits et attente de la fin du logout avant redirection.

## Stratégie Git

- branche créée directement depuis `develop` ;
- reprise ciblée des cinq commits issus des rebase-merges #1311 et #1304 ;
- aucun merge global de `frontend-frigo` vers `develop`.

## Validation

La validation complète est déléguée à la CI GitHub sur cette PR.