### PR TITLE
feat(onboarding): retours design sur l'environnement et la charte

### DIFF
--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -19,7 +19,7 @@ const PROGRESS_ERROR_MESSAGE =
 
 const OnboardingLayout = () => {
   const { classes } = useStyles()
-  const { screen, currentStep, screenConfig, stepProgress, primaryLabel, saving, error, goNext, goBack } =
+  const { screen, currentStep, screenConfig, stepProgress, primaryLabel, canProceed, saving, error, goNext, goBack } =
     useOnboarding()
 
   const ActiveScreen = screenConfig?.component
@@ -48,7 +48,7 @@ const OnboardingLayout = () => {
         className={classes.nextButton}
         variant="contained"
         onClick={goNext}
-        disabled={saving}
+        disabled={saving || !canProceed}
         endIcon={<ArrowForwardIcon />}
       >
         {primaryLabel}

--- a/src/views/Onboarding/OnboardingContext.tsx
+++ b/src/views/Onboarding/OnboardingContext.tsx
@@ -27,6 +27,10 @@ type OnboardingContextValue = {
   stepProgress: number
   screenConfig?: OnboardingScreenConfig
   primaryLabel: string
+  /** False while a screen still awaits its required acknowledgement, blocking the primary button. */
+  canProceed: boolean
+  acknowledged: boolean
+  setAcknowledged: (value: boolean) => void
   goNext: () => void
   goBack: () => void
 }
@@ -60,6 +64,7 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
   const [currentStep, setCurrentStep] = useState(() => clampStep(initialStep))
   const [subStep, setSubStep] = useState(0)
   const [screen, setScreen] = useState<OnboardingScreen>(() => (initialStep <= 0 ? 'welcome' : 'steps'))
+  const [acknowledged, setAcknowledged] = useState(false)
 
   const value = useMemo<OnboardingContextValue>(() => {
     const screenCount = getStepScreenCount(currentStep)
@@ -67,8 +72,11 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
     const isFirstStep = currentStep === 0 && subStep === 0
     const isLastStep = isLastMacroStep && subStep === screenCount - 1
     const screenConfig = screen === 'steps' ? getScreenConfig(currentStep, subStep) : undefined
+    const canProceed = !screenConfig?.requiresAcknowledgement || acknowledged
 
     const advance = () => {
+      // A fresh screen must earn its own acknowledgement again.
+      setAcknowledged(false)
       // Progress is persisted per macro step, only once its last screen is left.
       if (subStep < screenCount - 1) {
         setSubStep((step) => step + 1)
@@ -82,7 +90,7 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
     }
 
     const goNext = () => {
-      if (saving) {
+      if (saving || !canProceed) {
         return
       }
       if (screen === 'welcome') {
@@ -102,6 +110,7 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
       if (screen === 'welcome') {
         return
       }
+      setAcknowledged(false)
       if (error) {
         resetAdvance()
         resetCharter()
@@ -133,10 +142,13 @@ export const OnboardingProvider = ({ initialStep, children }: ProviderProps) => 
       stepProgress: screen === 'welcome' ? 0 : subStep / screenCount,
       screenConfig,
       primaryLabel: screenConfig?.primaryAction?.label ?? defaultLabel,
+      canProceed,
+      acknowledged,
+      setAcknowledged,
       goNext,
       goBack
     }
-  }, [screen, currentStep, subStep, saving, error, persistStep, signCharter, resetAdvance, resetCharter])
+  }, [screen, currentStep, subStep, acknowledged, saving, error, persistStep, signCharter, resetAdvance, resetCharter])
 
   return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>
 }

--- a/src/views/Onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/Onboarding/__tests__/Onboarding.test.tsx
@@ -89,6 +89,27 @@ describe('Onboarding page', () => {
     expect(screen.queryByTestId('onboarding-warning')).not.toBeInTheDocument()
   })
 
+  it('holds the charter signature until the consent is ticked', async () => {
+    signCharter.mockResolvedValue({ charter_signed_at: '2026-01-01T00:00:00Z' })
+    const user = userEvent.setup()
+    renderAt({ ...baseStatus, onboarding_step: 1 })
+
+    // Walk the commitments screens down to the charter.
+    for (let i = 0; i < 7; i++) {
+      await user.click(screen.getByRole('button', { name: /Continuer/ }))
+    }
+
+    expect(screen.getByRole('heading', { name: "Signer la charte d'engagement" })).toBeInTheDocument()
+    const sign = screen.getByRole('button', { name: /Signer/ })
+    expect(sign).toBeDisabled()
+
+    await user.click(screen.getByRole('checkbox', { name: /Je certifie avoir pris connaissance/ }))
+    expect(sign).toBeEnabled()
+
+    await user.click(sign)
+    await waitFor(() => expect(signCharter).toHaveBeenCalledTimes(1))
+  })
+
   it('closes the journey on the guided tour, with a button to the application', () => {
     renderAt({ ...baseStatus, onboarding_step: 2 }, { deidentified: false } as MeState)
     expect(screen.getByRole('heading', { name: 'Prendre en main Cohort360' })).toBeInTheDocument()

--- a/src/views/Onboarding/__tests__/OnboardingContext.test.tsx
+++ b/src/views/Onboarding/__tests__/OnboardingContext.test.tsx
@@ -174,6 +174,7 @@ describe('OnboardingContext', () => {
     const { result } = renderOnboarding(1)
     await goToCharter(result)
 
+    act(() => result.current.setAcknowledged(true))
     await act(async () => {
       result.current.goNext()
     })
@@ -188,6 +189,7 @@ describe('OnboardingContext', () => {
     const { result } = renderOnboarding(1)
     await goToCharter(result)
 
+    act(() => result.current.setAcknowledged(true))
     await act(async () => {
       result.current.goNext()
     })
@@ -230,12 +232,14 @@ describe('OnboardingContext', () => {
   it('does not sign twice when stepping back from the confirmation screen', async () => {
     const { result } = renderOnboarding(1)
     await goToCharter(result)
+    act(() => result.current.setAcknowledged(true))
     await act(async () => {
       result.current.goNext()
     })
 
     act(() => result.current.goBack())
     expect(result.current.subStep).toBe(CHARTER_SUBSTEP)
+    act(() => result.current.setAcknowledged(true))
     await act(async () => {
       result.current.goNext()
     })

--- a/src/views/Onboarding/screens/commitments/CharterSignature.tsx
+++ b/src/views/Onboarding/screens/commitments/CharterSignature.tsx
@@ -1,13 +1,18 @@
-import { Box, Link, Typography } from '@mui/material'
+import { Box, Checkbox, Divider, FormControlLabel, Link, Typography } from '@mui/material'
 import React from 'react'
 
+import { useOnboarding } from '../../OnboardingContext'
 import useStyles from '../../styles'
 
 const CHARTER_PDF_URL = '/documents/charte-engagement-cohort360.pdf'
 const CHARTER_PDF_EMBED_URL = `${CHARTER_PDF_URL}#navpanes=0&toolbar=0&statusbar=0&view=FitH`
 
+export const CHARTER_CONSENT_TEXT =
+  'Je certifie avoir pris connaissance de mes responsabilités vis-à-vis de l’utilisation des données mises à disposition dans Cohort360 et je m’engage à les respecter.'
+
 const CharterSignature = () => {
   const { classes } = useStyles()
+  const { acknowledged, setAcknowledged } = useOnboarding()
 
   return (
     <Box>
@@ -22,7 +27,9 @@ const CharterSignature = () => {
           aria-label="Charte d'engagement Cohort360"
         >
           <Box className={classes.documentFallback}>
-            <Typography>Votre navigateur ne peut pas afficher la charte directement.</Typography>
+            <Typography className={classes.rowLabel}>
+              Votre navigateur ne peut pas afficher la charte directement.
+            </Typography>
             <Link className={classes.link} href={CHARTER_PDF_URL} target="_blank" rel="noopener noreferrer">
               Ouvrir la charte d'engagement
             </Link>
@@ -34,6 +41,18 @@ const CharterSignature = () => {
           Télécharger une copie de la charte d'engagement
         </Link>
       </Box>
+      <Divider className={classes.divider} />
+      <FormControlLabel
+        className={classes.consentRow}
+        control={
+          <Checkbox
+            className={classes.consentCheckbox}
+            checked={acknowledged}
+            onChange={(event) => setAcknowledged(event.target.checked)}
+          />
+        }
+        label={<Typography className={classes.consentText}>{CHARTER_CONSENT_TEXT}</Typography>}
+      />
     </Box>
   )
 }

--- a/src/views/Onboarding/screens/commitments/__tests__/CharterSignature.test.tsx
+++ b/src/views/Onboarding/screens/commitments/__tests__/CharterSignature.test.tsx
@@ -1,21 +1,46 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 
+import { OnboardingProvider } from '../../../OnboardingContext'
 import CharterSignature from '../CharterSignature'
 
 const CHARTER_PDF_URL = '/documents/charte-engagement-cohort360.pdf'
 
+const renderCharter = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <OnboardingProvider initialStep={1}>
+        <CharterSignature />
+      </OnboardingProvider>
+    </QueryClientProvider>
+  )
+}
+
 describe('CharterSignature (RG3309.01)', () => {
   it('embeds the charter as a scrollable PDF document', () => {
-    render(<CharterSignature />)
+    renderCharter()
     const document = screen.getByLabelText("Charte d'engagement Cohort360")
     expect(document).toHaveAttribute('data', `${CHARTER_PDF_URL}#navpanes=0&toolbar=0&statusbar=0&view=FitH`)
     expect(document).toHaveAttribute('type', 'application/pdf')
   })
 
   it('offers a fallback link for browsers that cannot render the PDF inline', () => {
-    render(<CharterSignature />)
+    renderCharter()
     expect(screen.getByRole('link', { name: "Ouvrir la charte d'engagement" })).toHaveAttribute('href', CHARTER_PDF_URL)
+  })
+
+  it('exposes the mandatory consent, unchecked at first', async () => {
+    const user = userEvent.setup()
+    renderCharter()
+
+    const consent = screen.getByRole('checkbox', { name: /Je certifie avoir pris connaissance/ })
+    expect(consent).not.toBeChecked()
+
+    await user.click(consent)
+    expect(consent).toBeChecked()
   })
 })

--- a/src/views/Onboarding/screens/environment/WhatIsCohort360.tsx
+++ b/src/views/Onboarding/screens/environment/WhatIsCohort360.tsx
@@ -12,11 +12,8 @@ const WhatIsCohort360 = () => {
         Qu'est-ce que Cohort360 ?
       </Typography>
       <Typography className={classes.sectionText}>
-        Cohort360 est un outil qui permet aux professionnels de santé de l'AP-HP{' '}
-        <strong>
-          de créer et de visualiser les données de groupes de patients (cohortes) en fonction de divers critères
-        </strong>
-        .
+        Cohort360 est un outil qui permet aux professionnels de santé de l'AP-HP de{' '}
+        <strong>visualiser les données de groupes de patients</strong> (cohortes) en fonction de divers critères.
       </Typography>
     </Box>
   )

--- a/src/views/Onboarding/screens/environment/__tests__/screens.test.tsx
+++ b/src/views/Onboarding/screens/environment/__tests__/screens.test.tsx
@@ -10,7 +10,7 @@ describe('WhatIsCohort360', () => {
   it('presents the tool', () => {
     render(<WhatIsCohort360 />)
     expect(screen.getByRole('heading')).toHaveTextContent("Qu'est-ce que Cohort360 ?")
-    expect(screen.getByText(/créer et de visualiser les données de groupes de patients/)).toBeInTheDocument()
+    expect(screen.getByText('visualiser les données de groupes de patients')).toBeInTheDocument()
   })
 })
 

--- a/src/views/Onboarding/steps.ts
+++ b/src/views/Onboarding/steps.ts
@@ -44,6 +44,8 @@ export type OnboardingScreenConfig = {
   /** `bare` drops the white card, for screens bringing their own container. */
   layout?: 'card' | 'bare'
   primaryAction?: OnboardingPrimaryAction
+  /** Holds the primary button until the screen reports an explicit acknowledgement. */
+  requiresAcknowledgement?: boolean
 }
 
 export type OnboardingStepConfig = {
@@ -83,6 +85,7 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
       {
         key: 'charter-signature',
         component: CharterSignature,
+        requiresAcknowledgement: true,
         primaryAction: {
           label: 'Signer',
           run: ({ signCharter }) => signCharter(),

--- a/src/views/Onboarding/styles.ts
+++ b/src/views/Onboarding/styles.ts
@@ -183,6 +183,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   intro: {
     color: T.muted,
     fontSize: 16,
+    lineHeight: '24px',
     marginTop: theme.spacing(2)
   },
   stepRow: {
@@ -209,7 +210,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   stepDesc: {
     color: T.muted,
-    fontSize: 16
+    fontSize: 16,
+    lineHeight: '24px'
   },
   error: {
     marginTop: theme.spacing(2),
@@ -219,7 +221,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     color: T.ink,
     fontSize: 16,
     marginTop: theme.spacing(2),
-    lineHeight: 1.6
+    lineHeight: '24px'
   },
   subTitle: {
     color: T.ink,
@@ -235,14 +237,15 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   rowLabel: {
     color: T.ink,
-    fontSize: 16
+    fontSize: 16,
+    lineHeight: '24px'
   },
   list: {
     color: T.ink,
     fontSize: 16,
     marginTop: theme.spacing(1.5),
     paddingLeft: theme.spacing(3),
-    lineHeight: 1.6,
+    lineHeight: '24px',
     '& li': {
       marginTop: theme.spacing(0.5)
     }
@@ -286,7 +289,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   infoText: {
     color: eds.blue[800],
     fontSize: 16,
-    lineHeight: 1.6
+    lineHeight: '24px'
   },
   loadingRow: {
     display: 'flex',
@@ -297,10 +300,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
     marginTop: theme.spacing(3)
   },
   fieldLabel: {
-    color: T.muted
+    color: T.muted,
+    fontSize: 16,
+    lineHeight: '24px'
   },
   fieldValue: {
     color: T.ink,
+    fontSize: 16,
+    lineHeight: '24px',
     fontWeight: 700
   },
   rightItem: {
@@ -315,6 +322,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   rightLabel: {
     color: T.ink,
+    fontSize: 16,
+    lineHeight: '24px',
     fontWeight: 700
   },
   tileGrid: {
@@ -329,6 +338,26 @@ const useStyles = makeStyles()((theme: Theme) => ({
     padding: theme.spacing(1, 3, 3),
     backgroundColor: T.tileBg
   },
+  consentRow: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(3),
+    marginLeft: 0,
+    marginRight: 0
+  },
+  consentCheckbox: {
+    paddingTop: 0,
+    color: eds.blue[400],
+    '&.Mui-checked': {
+      color: eds.blue[400]
+    }
+  },
+  consentText: {
+    color: T.ink,
+    fontSize: 16,
+    lineHeight: '24px'
+  },
   warningNotice: {
     display: 'flex',
     alignItems: 'center',
@@ -339,9 +368,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
     flexShrink: 0
   },
   warningText: {
-    color: T.warning,
-    fontWeight: 600,
-    lineHeight: 1.5
+    color: T.ink,
+    fontSize: 16,
+    lineHeight: '24px'
   },
   illustrationRow: {
     display: 'flex',


### PR DESCRIPTION
## Objectif
Appliquer les retours de design sur le parcours d'onboarding : harmonisation typographique, allègement du warning des règles d'utilisation, contenu revu de l'écran de présentation, et consentement explicite avant signature de la charte.

Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3399

## Changements réalisés
- Textes courants (hors stepper) en 16px / line-height 24px, y compris les champs de « Comprendre votre accès » qui héritaient du corps par défaut.
- Warning rose des règles d'utilisation passé en texte courant (icône conservée).
- Contenu de « Qu'est-ce que Cohort360 ? » mis à jour, avec « visualiser les données de groupes de patients » en gras.
- Séparateur et case à cocher obligatoire sur l'écran de la charte : le bouton « Signer » reste désactivé tant que le consentement n'est pas coché, l'acquittement se réinitialise à chaque navigation.

## Impacts
Front uniquement.

## Tests réalisés
Tests unitaires et d'intégration ajoutés/mis à jour (gate de la charte, case de consentement, contenu).

## Risques
Faibles, périmètre limité au parcours d'onboarding.