### PR TITLE
fix: corrige l'integrite SRI de Leaflet en qualif

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link
       rel="stylesheet"
       href="/leaflet.css"
-      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      integrity="sha256-M3v8pcq9A7OYFbJwD+vis7ft9VkhxZzUn4jssyghIwM="
       crossorigin=""
     />
     <script type="text/javascript">


### PR DESCRIPTION
## Correctif

Met a jour l'empreinte SRI de public/leaflet.css declaree dans index.html.

## Cause racine

En qualif, le CSS Leaflet au format LF ne correspondait plus a l'empreinte SRI issue de la version CRLF. Le navigateur bloquait donc la feuille de style, ce qui faisait passer les tuiles Leaflet en position static.

## Impact

Les tuiles Leaflet sont de nouveau positionnees correctement apres chargement de la feuille CSS.

## Validation

- Empreinte SHA-256 recalculee depuis public/leaflet.css et comparee a celle declaree dans index.html.
- git diff --check valide.
- La build Vite n'a pas produit d'erreur mais a depasse le delai d'execution local de 2 minutes.