### PR TITLE
fix(auth): ne plus deconnecter l'utilisateur sur une 403 de droits

### DIFF
--- a/src/services/__tests__/apiClients.test.ts
+++ b/src/services/__tests__/apiClients.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import type { AxiosInterceptorManager, InternalAxiosRequestConfig } from 'axios'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import type { AxiosError, AxiosInterceptorManager, AxiosResponseHeaders, InternalAxiosRequestConfig } from 'axios'
 import { ACCESS_TOKEN } from 'constants.js'
 
 vi.mock('config', () => ({
@@ -17,10 +17,20 @@ import apiFhir, { getAuthorizationMethod } from 'services/apiFhir'
 
 type InterceptorHandler = {
   fulfilled?: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>
+  rejected?: (error: AxiosError) => unknown
 }
 
 const getRequestHandler = (interceptors: AxiosInterceptorManager<InternalAxiosRequestConfig>) =>
   (interceptors as unknown as { handlers: InterceptorHandler[] }).handlers[0].fulfilled
+
+const getResponseErrorHandler = () =>
+  (apiBackend.interceptors.response as unknown as { handlers: InterceptorHandler[] }).handlers[0].rejected
+
+const buildError = (status: number, url: string) =>
+  ({
+    config: { url, headers: {} as AxiosResponseHeaders },
+    response: { status, data: {}, statusText: '', headers: {}, config: { url } }
+  }) as unknown as AxiosError
 
 describe('api clients interceptors', () => {
   beforeEach(() => {
@@ -63,5 +73,46 @@ describe('api clients interceptors', () => {
     expect(getAuthorizationMethod()).toBe('JWT')
     localStorage.setItem('oidcAuth', 'true')
     expect(getAuthorizationMethod()).toBe('OIDC')
+  })
+})
+
+describe('gestion des réponses en erreur sur apiBackend', () => {
+  const assign = vi.fn()
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    assign.mockClear()
+    localStorage.clear()
+    localStorage.setItem(ACCESS_TOKEN, 'access-value')
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/exports', assign },
+      writable: true,
+      configurable: true
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true, configurable: true })
+  })
+
+  it('déconnecte sur une 401', () => {
+    getResponseErrorHandler()?.(buildError(401, '/exports/'))
+
+    expect(assign).toHaveBeenCalledWith('/')
+    expect(localStorage.getItem(ACCESS_TOKEN)).toBeNull()
+  })
+
+  it('déconnecte sur une 403 renvoyée par le rafraîchissement du token', () => {
+    getResponseErrorHandler()?.(buildError(403, '/auth/refresh/'))
+
+    expect(assign).toHaveBeenCalledWith('/')
+    expect(localStorage.getItem(ACCESS_TOKEN)).toBeNull()
+  })
+
+  it('laisse la session intacte sur une 403 de droits', () => {
+    getResponseErrorHandler()?.(buildError(403, '/exports/some-uuid/retry/'))
+
+    expect(assign).not.toHaveBeenCalled()
+    expect(localStorage.getItem(ACCESS_TOKEN)).toBe('access-value')
   })
 })

--- a/src/services/apiBackend.ts
+++ b/src/services/apiBackend.ts
@@ -1,6 +1,8 @@
-import axios, { InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios'
 import { ACCESS_TOKEN } from '../constants'
 import { getConfig, onUpdateConfig } from 'config'
+
+const REFRESH_TOKEN_URL = '/auth/refresh/'
 
 const apiBackend = axios.create({
   baseURL: getConfig().system.backendUrl,
@@ -35,13 +37,17 @@ apiBackend.interceptors.request.use((config) => {
   return config
 })
 
+// une 403 sur /auth/refresh/ signifie que l'access token a expiré, les autres 403 sont des refus de droits
+const isSessionLost = (error: AxiosError) =>
+  error.response?.status === 401 || (error.response?.status === 403 && !!error.config?.url?.includes(REFRESH_TOKEN_URL))
+
 apiBackend.interceptors.response.use(
   (response) => {
     return response
   },
   function (error) {
     if (error.response) {
-      if ((error.response.status === 401 || error.response.status === 403) && window.location.pathname !== '/') {
+      if (isSessionLost(error) && window.location.pathname !== '/') {
         localStorage.clear()
         window.location.assign('/')
       }


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3415

Une 403 vidait le localStorage et renvoyait sur la page de connexion, ce qui ejectait l'utilisateur de l'application sur un simple refus de droits.

## Changements realises
L'intercepteur de reponse de `apiBackend` ne deconnecte plus que sur une 401, et sur une 403 uniquement quand elle vient de `/auth/refresh/`. Le back renvoyant une 403 sur cet appel quand l'access token a expire, la sortie de session reste couverte, comme dans l'AdministrationPortal.

## Impacts
Front, gestion de session.

## Tests realises
Unitaires.

## Risques
Les 403 metier ne sont plus signalees a l'utilisateur, l'appel echoue silencieusement.