### PR TITLE
fix(export): exporter automatiquement patient__identifier avec Patient

### DIFF
--- a/src/__tests__/components/ExportTable.test.tsx
+++ b/src/__tests__/components/ExportTable.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { AppConfig, getConfig } from 'config'
+import { TableInfo, TableSetting } from 'types/export'
+import { Cohort } from 'types'
+
+// Mocks des dépendances lourdes (services, utils de count, store)
+vi.mock('pages/ExportRequest/components/exportUtils', () => ({
+  getResourceType: vi.fn(() => 'Patient'),
+  getExportTableLabel: vi.fn(() => 'Patient'),
+  fetchResourceCount2: vi.fn(async () => 42),
+  fetchQuestionnaireResponseCountDetails: vi.fn(async () => [])
+}))
+
+vi.mock('services/aphp/serviceFilters', () => ({
+  getProviderFilters: vi.fn(async () => [])
+}))
+
+const dispatch = vi.fn()
+vi.mock('state', () => ({
+  useAppDispatch: () => dispatch,
+  useAppSelector: (selector: (s: unknown) => unknown) => selector({ me: { id: 'user-1' } })
+}))
+
+vi.mock('state/warningDialog', () => ({
+  showDialog: vi.fn((p) => ({ type: 'show', payload: p })),
+  hideDialog: vi.fn(() => ({ type: 'hide' }))
+}))
+
+import ExportTable from 'pages/ExportRequest/components/ExportTable'
+
+const tableInfo: TableInfo = {
+  name: 'person',
+  columns: ['col1', 'col2'],
+  fhirResourceName: 'Patient',
+  isFhirStandard: true,
+  isOmopStandard: false
+}
+
+const tableSetting: TableSetting = {
+  tableName: 'person',
+  isChecked: true,
+  columns: ['col1'],
+  fhirFilter: null,
+  respectTableRelationships: true,
+  pivotMergeColumns: [],
+  pivotMergeIds: []
+} as never
+
+const cohort = { uuid: 'c1', group_id: 'g1', name: 'Cohorte' } as Cohort
+
+const renderTable = (props: Partial<Parameters<typeof ExportTable>[0]> = {}) =>
+  render(
+    <AppConfig.Provider value={getConfig()}>
+      <ExportTable
+        exportTable={tableInfo}
+        exportTableSettings={tableSetting}
+        exportCohort={cohort}
+        setError={vi.fn()}
+        addNewTableSetting={vi.fn()}
+        removeTableSetting={vi.fn()}
+        onChangeTableSettings={vi.fn()}
+        compatibilitiesTables={null}
+        exportTypeFile="csv"
+        oneFile={false}
+        selectedTablesCount={1}
+        {...props}
+      />
+    </AppConfig.Provider>
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ExportTable', () => {
+  it('affiche le libellé de la table', async () => {
+    renderTable()
+    expect(await screen.findByText('Patient')).toBeInTheDocument()
+  })
+
+  it('affiche le nombre de lignes récupéré via fetchResourceCount2', async () => {
+    renderTable()
+    await waitFor(() => {
+      expect(screen.getByText(/42/)).toBeInTheDocument()
+    })
+  })
+
+  it('permet de cocher/décocher la table', () => {
+    const onChangeTableSettings = vi.fn()
+    const addNewTableSetting = vi.fn()
+    renderTable({ onChangeTableSettings, addNewTableSetting })
+    const checkbox = screen.getAllByRole('checkbox')[0]
+    fireEvent.click(checkbox)
+    // une action de mise à jour ou d'ajout est déclenchée
+    expect(onChangeTableSettings.mock.calls.length + addNewTableSetting.mock.calls.length).toBeGreaterThan(0)
+  })
+
+  it('gère une table non cochée', async () => {
+    renderTable({ exportTableSettings: { ...tableSetting, isChecked: false } as never })
+    expect(await screen.findByText('Patient')).toBeInTheDocument()
+  })
+
+  it('signale la sous-table patient__identifier sur la table Patient', async () => {
+    renderTable({ exportTable: { ...tableInfo, name: 'Patient' } })
+    expect(await screen.findByText(/patient__identifier sera également exportée/)).toBeInTheDocument()
+  })
+
+  it("masque la mention de patient__identifier en export regroupé lorsqu'une autre table est sélectionnée", async () => {
+    renderTable({ exportTable: { ...tableInfo, name: 'Patient' }, oneFile: true, selectedTablesCount: 2 })
+    await screen.findAllByText('Patient')
+    expect(screen.queryByText(/patient__identifier sera également exportée/)).not.toBeInTheDocument()
+  })
+
+  it('conserve la mention de patient__identifier en export regroupé sur la seule table Patient', async () => {
+    renderTable({ exportTable: { ...tableInfo, name: 'Patient' }, oneFile: true, selectedTablesCount: 1 })
+    expect(await screen.findByText(/patient__identifier sera également exportée/)).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/services/serviceExportCohort.test.ts
+++ b/src/__tests__/services/serviceExportCohort.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { AxiosResponse } from 'axios'
+import { Direction, Order } from 'types/searchCriterias'
+
+vi.mock('config', () => ({
+  getConfig: vi.fn(() => ({ features: { export: { exportTables: ['patient', 'condition'] } } }))
+}))
+
+vi.mock('services/aphp/callApi', () => ({
+  fetchExportTableInfo: vi.fn(),
+  fetchExportTableRelationInfo: vi.fn(),
+  fetchExportList: vi.fn(),
+  retryExport: vi.fn()
+}))
+
+vi.mock('services/apiBackend', () => ({
+  default: { get: vi.fn(), post: vi.fn() }
+}))
+
+import {
+  fetchExportTableInfo,
+  fetchExportTableRelationInfo,
+  fetchExportList,
+  retryExport as _retryExport
+} from 'services/aphp/callApi'
+import apiBackend from 'services/apiBackend'
+import {
+  fetchExportTablesInfo,
+  fetchExportTablesRelationsInfo,
+  retryExport,
+  fetchExportsList,
+  postExportCohort
+} from 'services/aphp/serviceExportCohort'
+
+const mockFetchTableInfo = vi.mocked(fetchExportTableInfo)
+const mockFetchRelationInfo = vi.mocked(fetchExportTableRelationInfo)
+const mockFetchList = vi.mocked(fetchExportList)
+const mockRetry = vi.mocked(_retryExport)
+const mockGet = vi.mocked(apiBackend.get)
+const mockPost = vi.mocked(apiBackend.post)
+
+const asAxios = <T,>(data: T, headers: Record<string, string> = {}): AxiosResponse<T> =>
+  ({ data, status: 200, statusText: 'OK', headers, config: {} }) as AxiosResponse<T>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('serviceExportCohort.fetchExportTablesInfo', () => {
+  it('retourne la réponse de callApi (nominal)', async () => {
+    mockFetchTableInfo.mockResolvedValue([{ name: 'patient' }] as never)
+    const result = await fetchExportTablesInfo()
+    expect(result).toEqual([{ name: 'patient' }])
+    expect(mockFetchTableInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ tableNames: ['patient', 'condition'] })
+    )
+  })
+
+  it('retourne [] en cas d’erreur', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockFetchTableInfo.mockRejectedValue(new Error('boom'))
+    expect(await fetchExportTablesInfo()).toEqual([])
+    errorSpy.mockRestore()
+  })
+})
+
+describe('serviceExportCohort.fetchExportTablesRelationsInfo', () => {
+  it('fusionne Hamiltonian, CentralTable et la liste initiale en dédupliquant', async () => {
+    mockFetchRelationInfo.mockResolvedValue({
+      verifiedRelations: [
+        { relation: 'Hamiltonian', candidates: ['a', 'b'] },
+        { relation: 'CentralTable', candidates: ['b', 'c'] }
+      ]
+    } as never)
+    const result = await fetchExportTablesRelationsInfo(['c', 'd'])
+    expect(result).toEqual(expect.arrayContaining(['a', 'b', 'c', 'd']))
+    // dédupliqué: 'b' et 'c' présents une seule fois
+    expect(result.filter((x) => x === 'b')).toHaveLength(1)
+    expect(result.filter((x) => x === 'c')).toHaveLength(1)
+  })
+
+  it('retourne la liste initiale quand aucune relation vérifiée', async () => {
+    mockFetchRelationInfo.mockResolvedValue({} as never)
+    const result = await fetchExportTablesRelationsInfo(['x'])
+    expect(result).toEqual(['x'])
+  })
+
+  it('retourne [] en cas d’erreur', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockFetchRelationInfo.mockRejectedValue(new Error('boom'))
+    expect(await fetchExportTablesRelationsInfo(['x'])).toEqual([])
+    errorSpy.mockRestore()
+  })
+})
+
+describe('serviceExportCohort.retryExport', () => {
+  it('retourne la réponse en cas de succès', async () => {
+    mockRetry.mockResolvedValue({ status: 'ok' } as never)
+    expect(await retryExport('id-1')).toEqual({ status: 'ok' })
+  })
+
+  it('retourne un résultat vide en cas d’erreur', async () => {
+    mockRetry.mockRejectedValue(new Error('boom'))
+    expect(await retryExport('id-1')).toEqual({ count: 0, results: [] })
+  })
+})
+
+describe('serviceExportCohort.fetchExportsList', () => {
+  it('calcule l’offset et l’ordre descendant', async () => {
+    mockFetchList.mockResolvedValue({ count: 1, results: [] } as never)
+    await fetchExportsList({
+      user: 'u1',
+      page: 3,
+      orderBy: { orderBy: Order.CREATED_AT, orderDirection: Direction.DESC }
+    })
+    expect(mockFetchList).toHaveBeenCalledWith(
+      expect.objectContaining({ user: 'u1', offset: 40, ordering: `-${Order.CREATED_AT}` })
+    )
+  })
+
+  it('utilise l’ordre ascendant sans préfixe', async () => {
+    mockFetchList.mockResolvedValue({ count: 0, results: [] } as never)
+    await fetchExportsList({
+      user: 'u1',
+      page: 1,
+      orderBy: { orderBy: Order.CREATED_AT, orderDirection: Direction.ASC }
+    })
+    expect(mockFetchList).toHaveBeenCalledWith(
+      expect.objectContaining({ offset: 0, ordering: Order.CREATED_AT })
+    )
+  })
+
+  it('retourne un résultat vide en cas d’erreur', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockFetchList.mockRejectedValue(new Error('boom'))
+    expect(
+      await fetchExportsList({ user: 'u1', page: 1, orderBy: { orderBy: Order.CREATED_AT, orderDirection: Direction.ASC } })
+    ).toEqual({ count: 0, results: [] })
+    errorSpy.mockRestore()
+  })
+})
+
+describe('serviceExportCohort.postExportCohort', () => {
+  it('construit le payload d’export à partir des tables', async () => {
+    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-1' }))
+    await postExportCohort({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cohortId: { uuid: 'cohort-1' } as any,
+      motivation: 'analyse',
+      group_tables: true,
+      outputFormat: 'csv',
+      tables: [
+        {
+          tableName: 'patient',
+          respectTableRelationships: true,
+          columns: ['id'],
+          fhirFilter: { uuid: 'filter-1' },
+          pivotMergeColumns: [],
+          pivotMergeIds: []
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
+      ]
+    })
+    expect(mockPost).toHaveBeenCalledWith(
+      '/exports/',
+      expect.objectContaining({
+        motivation: 'analyse',
+        output_format: 'csv',
+        group_tables: true,
+        nominative: true,
+        shift_date: false,
+        export_tables: [
+          expect.objectContaining({
+            table_name: 'patient',
+            cohort_result_source: 'cohort-1',
+            fhir_filter: 'filter-1'
+          })
+        ]
+      })
+    )
+  })
+
+  it('ajoute automatiquement patient__identifier quand Patient est sélectionné', async () => {
+    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-3' }))
+    await postExportCohort({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cohortId: { uuid: 'cohort-3' } as any,
+      motivation: 'analyse',
+      group_tables: false,
+      outputFormat: 'csv',
+      tables: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any
+      ]
+    })
+    const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string; cohort_result_source: string }[] }
+    const tableNames = payload.export_tables.map((table) => table.table_name)
+    expect(tableNames).toEqual(['Patient', 'patient__identifier'])
+    payload.export_tables.forEach((table) => {
+      expect(table.cohort_result_source).toBe('cohort-3')
+    })
+  })
+
+  it('ne duplique pas une sous-table liée déjà sélectionnée', async () => {
+    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-4' }))
+    await postExportCohort({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cohortId: { uuid: 'cohort-4' } as any,
+      motivation: 'analyse',
+      group_tables: false,
+      outputFormat: 'csv',
+      tables: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { tableName: 'patient__identifier', respectTableRelationships: true, columns: null, fhirFilter: null } as any
+      ]
+    })
+    const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string }[] }
+    const tableNames = payload.export_tables.map((table) => table.table_name)
+    expect(tableNames).toEqual(['Patient', 'patient__identifier'])
+    expect(tableNames.filter((name) => name === 'patient__identifier')).toHaveLength(1)
+  })
+
+  it("n'ajoute pas patient__identifier en export regroupé quand une autre table est sélectionnée", async () => {
+    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-5' }))
+    await postExportCohort({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cohortId: { uuid: 'cohort-5' } as any,
+      motivation: 'analyse',
+      group_tables: true,
+      outputFormat: 'csv',
+      tables: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { tableName: 'visit_occurrence', respectTableRelationships: true, columns: null, fhirFilter: null } as any
+      ]
+    })
+    const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string }[] }
+    const tableNames = payload.export_tables.map((table) => table.table_name)
+    expect(tableNames).toEqual(['Patient', 'visit_occurrence'])
+  })
+
+  it('ajoute patient__identifier en export regroupé quand Patient est la seule table sélectionnée', async () => {
+    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-6' }))
+    await postExportCohort({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cohortId: { uuid: 'cohort-6' } as any,
+      motivation: 'analyse',
+      group_tables: true,
+      outputFormat: 'csv',
+      tables: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any
+      ]
+    })
+    const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string }[] }
+    const tableNames = payload.export_tables.map((table) => table.table_name)
+    expect(tableNames).toEqual(['Patient', 'patient__identifier'])
+  })
+
+  it('omet fhir_filter quand aucun filtre n’est fourni', async () => {
+    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-2' }))
+    await postExportCohort({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cohortId: { uuid: 'cohort-2' } as any,
+      motivation: '',
+      group_tables: false,
+      outputFormat: 'xlsx',
+      tables: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { tableName: 'condition', respectTableRelationships: false, columns: [], pivotMergeColumns: [], pivotMergeIds: [] } as any
+      ]
+    })
+    const payload = mockPost.mock.calls[0][1] as { export_tables: Record<string, unknown>[] }
+    expect(payload.export_tables[0]).not.toHaveProperty('fhir_filter')
+  })
+})

--- a/src/pages/ExportRequest/components/ExportForm/index.tsx
+++ b/src/pages/ExportRequest/components/ExportForm/index.tsx
@@ -388,6 +388,7 @@ const ExportForm: React.FC = () => {
         compatibilitiesTables={compatibilitiesTables}
         exportTypeFile={exportTypeFile}
         oneFile={oneFile}
+        selectedTablesCount={tablesSettings.length}
       />
     ))
   }, [
@@ -400,7 +401,8 @@ const ExportForm: React.FC = () => {
     onChangeTableSettings,
     compatibilitiesTables,
     exportTypeFile,
-    oneFile
+    oneFile,
+    tablesSettings.length
   ])
 
   return (

--- a/src/pages/ExportRequest/components/ExportTable/index.tsx
+++ b/src/pages/ExportRequest/components/ExportTable/index.tsx
@@ -60,6 +60,7 @@ type ExportTableProps = {
   compatibilitiesTables: string[] | null
   exportTypeFile: 'xlsx' | 'csv'
   oneFile: boolean
+  selectedTablesCount: number
 }
 
 /**
@@ -102,7 +103,8 @@ const ExportTable: React.FC<ExportTableProps> = ({
   onChangeTableSettings,
   compatibilitiesTables,
   exportTypeFile,
-  oneFile
+  oneFile,
+  selectedTablesCount
 }) => {
   const dispatch = useAppDispatch()
   const userId = useAppSelector((state) => state.me?.id)
@@ -294,6 +296,11 @@ const ExportTable: React.FC<ExportTableProps> = ({
               {']'}
             </Typography>
           </div>
+          {exportTable.name === 'Patient' && (!oneFile || selectedTablesCount === 1) && (
+            <Typography variant="caption" fontStyle="italic" color="#888" sx={{ width: '100%', mt: '4px' }}>
+              La sous-table patient__identifier sera également exportée avec la table Patient.
+            </Typography>
+          )}
         </Grid>
 
         <Grid container size={4}>

--- a/src/services/aphp/serviceExportCohort.ts
+++ b/src/services/aphp/serviceExportCohort.ts
@@ -135,6 +135,10 @@ export const fetchExportsList = async (
   }
 }
 
+const AUTO_LINKED_TABLES: Record<string, string[]> = {
+  Patient: ['patient__identifier']
+}
+
 export const postExportCohort = async ({
   cohortId,
   motivation,
@@ -151,18 +155,41 @@ export const postExportCohort = async ({
   const nominative = true
   const shift_date = false
 
+  const export_tables = tables.map((table: TableSetting) => ({
+    table_name: table.tableName,
+    cohort_result_source: cohortId?.uuid,
+    respect_table_relationships: table.respectTableRelationships,
+    columns: table.columns,
+    ...(table.fhirFilter && { fhir_filter: table.fhirFilter?.uuid }),
+    pivot_merge_columns: table.pivotMergeColumns,
+    //pivot_split_columns : table.pivotSplitColumns,
+    pivot_merge_ids: table.pivotMergeIds
+  }))
+  // En export regroupé, une sous-table ne partage un lien hamiltonien avec sa table parente que si
+  // celle-ci est seule : au-delà, le dataexporter refuse la jointure sur clé primaire.
+  if (!group_tables || tables.length === 1) {
+    const existingTableNames = new Set(export_tables.map((table) => table.table_name))
+    tables.forEach((table: TableSetting) => {
+      const linkedTables = AUTO_LINKED_TABLES[table.tableName]
+      if (!linkedTables) return
+      linkedTables.forEach((linkedTableName) => {
+        if (existingTableNames.has(linkedTableName)) return
+        existingTableNames.add(linkedTableName)
+        export_tables.push({
+          table_name: linkedTableName,
+          cohort_result_source: cohortId?.uuid,
+          respect_table_relationships: table.respectTableRelationships,
+          columns: null,
+          pivot_merge_columns: undefined,
+          pivot_merge_ids: undefined
+        })
+      })
+    })
+  }
+
   return await apiBackend.post<Export>('/exports/', {
     motivation,
-    export_tables: tables.map((table: TableSetting) => ({
-      table_name: table.tableName,
-      cohort_result_source: cohortId?.uuid,
-      respect_table_relationships: table.respectTableRelationships,
-      columns: table.columns,
-      ...(table.fhirFilter && { fhir_filter: table.fhirFilter?.uuid }),
-      pivot_merge_columns: table.pivotMergeColumns,
-      //pivot_split_columns : table.pivotSplitColumns,
-      pivot_merge_ids: table.pivotMergeIds
-    })),
+    export_tables,
     nominative: nominative,
     shift_date: shift_date,
     output_format: outputFormat,


### PR DESCRIPTION
## Objectif
Permettre de retrouver les IPP dans l'export, la colonne `patient_source_value` ayant disparu avec la migration BC3.1.

Fixes [#3397](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3397)

## Changements réalisés
La table `patient__identifier` est ajoutée au payload d'export dès que `Patient` est sélectionnée, et un libellé le signale sous le bloc `Patient`. En export regroupé, l'ajout n'a lieu que si `Patient` est la seule table sélectionnée.

## Impacts
Front, exports.

## Tests réalisés
Tests unitaires ajoutés sur le service d'export et sur le composant.

## Risques
En export regroupé avec plusieurs tables, l'IPP n'est pas joint : `patient__identifier` ne partage pas de lien hamiltonien avec `Patient` dès qu'une autre table est présente.
