### PR TITLE
feat(onboarding): révise les textes du parcours selon les maquettes V2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,8 +88,6 @@
         "@types/react-dom": "^19.1.7",
         "@types/react-html-parser": "^2.0.2",
         "@types/react-redux": "^7.1.25",
-        "@types/react-router": "^5.1.20",
-        "@types/react-router-dom": "^5.3.3",
         "@types/react-window": "^1.8.8",
         "@types/redux-logger": "^3.0.9",
         "@types/uuid": "^10.0.0",
@@ -4324,13 +4322,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
@@ -4559,29 +4550,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -117,8 +117,6 @@
     "@types/react-dom": "^19.1.7",
     "@types/react-html-parser": "^2.0.2",
     "@types/react-redux": "^7.1.25",
-    "@types/react-router": "^5.1.20",
-    "@types/react-router-dom": "^5.3.3",
     "@types/react-window": "^1.8.8",
     "@types/redux-logger": "^3.0.9",
     "@types/uuid": "^10.0.0",

--- a/src/views/Onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/Onboarding/__tests__/Onboarding.test.tsx
@@ -112,7 +112,7 @@ describe('Onboarding page', () => {
 
   it('closes the journey on the guided tour, with a button to the application', () => {
     renderAt({ ...baseStatus, onboarding_step: 2 }, { deidentified: false } as MeState)
-    expect(screen.getByRole('heading', { name: 'Prendre en main Cohort360' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: "Prendre en main l'outil" })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Accéder à Cohort360/ })).toBeInTheDocument()
   })
 

--- a/src/views/Onboarding/screens/commitments/UsageRules.tsx
+++ b/src/views/Onboarding/screens/commitments/UsageRules.tsx
@@ -1,8 +1,11 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Link, Typography } from '@mui/material'
 import React from 'react'
 
 import useStyles from '../../styles'
 import WarningNotice from '../../WarningNotice'
+
+const EDS_ACCESS_RULES_URL = 'https://eds.aphp.fr/wp-content/uploads/2024/11/Regles-Acces_EDS-APHP_20210209.pdf'
+const DATA_PROTECTION_ACT_URL = 'https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000886460/'
 
 const UsageRules = () => {
   const { classes } = useStyles()
@@ -13,9 +16,26 @@ const UsageRules = () => {
         Les règles d'utilisation des données dans Cohort360
       </Typography>
       <Typography className={classes.sectionText}>
-        En demandant un accès à Cohort360, vous vous engagez à respecter plusieurs règles d'utilisation des données de
-        santé de l'EDS.
+        En accédant à Cohort360, vous vous engagez à respecter plusieurs règles d'utilisation des données de santé de
+        l'EDS.
       </Typography>
+      <Typography className={classes.sectionText}>
+        Les règles d'utilisation qui vont vous être présentées sont conformes :
+      </Typography>
+      <ul className={classes.list}>
+        <li>
+          <Link className={classes.inlineLink} href={EDS_ACCESS_RULES_URL} target="_blank" rel="noopener noreferrer">
+            aux règles d'accès à l'EDS de l'AP-HP à des fins de recherche
+          </Link>
+        </li>
+        <li>
+          aux dispositions réglementaires applicables, notamment issues du{' '}
+          <Link className={classes.inlineLink} href={DATA_PROTECTION_ACT_URL} target="_blank" rel="noopener noreferrer">
+            Règlement général sur la protection des données, de la loi n° 78-17 du 6 janvier 1978 relative à
+            l'informatique, aux fichiers et aux libertés modifiée, et du code pénal.
+          </Link>
+        </li>
+      </ul>
       <WarningNotice />
     </Box>
   )

--- a/src/views/Onboarding/screens/commitments/__tests__/screens.test.tsx
+++ b/src/views/Onboarding/screens/commitments/__tests__/screens.test.tsx
@@ -14,6 +14,12 @@ describe('UsageRules', () => {
     expect(screen.getByRole('heading')).toHaveTextContent("Les règles d'utilisation des données dans Cohort360")
     expect(screen.getByTestId('onboarding-warning')).toBeInTheDocument()
   })
+
+  it('lists the texts the rules comply with', () => {
+    render(<UsageRules />)
+    expect(screen.getByText(/règles d'accès à l'EDS de l'AP-HP à des fins de recherche/)).toBeInTheDocument()
+    expect(screen.getByText(/loi n° 78-17 du 6 janvier 1978/)).toBeInTheDocument()
+  })
 })
 
 describe('DataCrossing', () => {

--- a/src/views/Onboarding/screens/environment/DataAccess.tsx
+++ b/src/views/Onboarding/screens/environment/DataAccess.tsx
@@ -20,7 +20,7 @@ const DataAccess = () => {
       </Typography>
       <ul className={classes.list}>
         <li>
-          <strong>Cas général :</strong> vous êtes rattaché à une ou plusieurs unités fonctionnelles : vous avez accès
+          <strong>Cas général :</strong> vous êtes rattaché à une ou plusieurs unités fonctionnelles, vous avez accès
           aux patients pris en charge par cette ou ces unités fonctionnelles.
         </li>
         <li>

--- a/src/views/Onboarding/screens/environment/UserRights.tsx
+++ b/src/views/Onboarding/screens/environment/UserRights.tsx
@@ -17,7 +17,7 @@ const UserRights = () => {
 
   const title = (
     <Typography variant="h4" className={classes.title}>
-      Comprendre votre accès
+      Comprendre votre habilitation
     </Typography>
   )
 
@@ -55,7 +55,7 @@ const UserRights = () => {
     <Box>
       {title}
       <Box className={classes.fieldBlock}>
-        <Typography className={classes.fieldLabel}>Utilisateur :</Typography>
+        <Typography className={classes.fieldLabel}>NOM Prénom de l'utilisateur :</Typography>
         <Typography className={classes.fieldValue}>{displayName}</Typography>
       </Box>
 
@@ -78,12 +78,14 @@ const UserRights = () => {
             </Box>
 
             <Box className={classes.fieldBlock}>
-              <Typography className={classes.fieldLabel}>Votre périmètre des données accessibles :</Typography>
+              <Typography className={classes.fieldLabel}>Votre périmètre de données accessibles :</Typography>
               <Typography className={classes.fieldValue}>{access.perimeter}</Typography>
             </Box>
 
             <Box className={classes.fieldBlock}>
-              <Typography className={classes.fieldLabel}>Date d'expiration de votre accès à Cohort360 :</Typography>
+              <Typography className={classes.fieldLabel}>
+                Date d'expiration de votre habilitation à Cohort360 :
+              </Typography>
               <Typography className={classes.fieldValue}>
                 {access.expirationDate ? moment(access.expirationDate).format('DD/MM/YYYY') : 'Non renseignée'}
               </Typography>

--- a/src/views/Onboarding/screens/environment/WhatIsCohort360.tsx
+++ b/src/views/Onboarding/screens/environment/WhatIsCohort360.tsx
@@ -12,8 +12,8 @@ const WhatIsCohort360 = () => {
         Qu'est-ce que Cohort360 ?
       </Typography>
       <Typography className={classes.sectionText}>
-        Cohort360 est un outil qui permet aux professionnels de santé de l'AP-HP de{' '}
-        <strong>visualiser les données de groupes de patients</strong> (cohortes) en fonction de divers critères.
+        C'est un outil de datavisualisation visant à constituer des cohortes de patients. Il permet de dénombrer des
+        patients, d'analyser des données de soin et de les extraire à des fins de recherche et d'analyse.
       </Typography>
     </Box>
   )

--- a/src/views/Onboarding/screens/environment/WhatIsEds.tsx
+++ b/src/views/Onboarding/screens/environment/WhatIsEds.tsx
@@ -3,7 +3,6 @@ import BiotechOutlinedIcon from '@mui/icons-material/BiotechOutlined'
 import ContactPageOutlinedIcon from '@mui/icons-material/ContactPageOutlined'
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined'
 import MedicationOutlinedIcon from '@mui/icons-material/MedicationOutlined'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { Box, Divider, Link, Typography } from '@mui/material'
 import type { SvgIconProps } from '@mui/material'
 import InfoBadge from 'components/ui/InfoBadge'
@@ -13,7 +12,7 @@ import { eds } from 'styles/palette'
 
 import useStyles from '../../styles'
 
-const EDS_URL = 'https://eds.aphp.fr/'
+const EDS_URL = 'https://panorama.eds.aphp.fr/explorer-les-donnees'
 
 type DataFamily = {
   label: string
@@ -34,12 +33,12 @@ const DATA_FAMILIES: DataFamily[] = [
   },
   {
     label: 'Médicaments',
-    description: 'Prescriptions, administrations',
+    description: 'Prescriptions et administrations.',
     icon: MedicationOutlinedIcon
   },
   {
     label: "Résultats d'examen",
-    description: 'Biologie, imagerie',
+    description: 'Biologie, imagerie…',
     icon: BiotechOutlinedIcon
   },
   {
@@ -58,16 +57,13 @@ const WhatIsEds = () => {
         Qu'est-ce que l'EDS ?
       </Typography>
       <Typography className={classes.sectionText}>
-        Cohort360 permet d'accéder à de nombreux{' '}
-        <strong>jeux de données, issues de l'Entrepôt de Données de Santé de l'AP-HP (EDS)</strong>. L'EDS centralise
-        toutes les données collectées dans les 38 hôpitaux de l'AP-HP.
-      </Typography>
-      <Box className={classes.linkRow}>
-        <Link className={classes.link} href={EDS_URL} target="_blank" rel="noopener noreferrer">
-          En savoir plus sur l'EDS
-          <OpenInNewIcon className={classes.linkIcon} fontSize="inherit" />
+        Cohort360 permet d'accéder à de nombreux <strong>jeux de données, issues des 38 hôpitaux de l'AP-HP</strong> et
+        centralisés dans{' '}
+        <Link className={classes.inlineLink} href={EDS_URL} target="_blank" rel="noopener noreferrer">
+          l'Entrepôt de Données de Santé (EDS)
         </Link>
-      </Box>
+        .
+      </Typography>
 
       <Typography className={classes.subTitle}>Les données de l'EDS</Typography>
       {DATA_FAMILIES.map(({ label, description, icon: Icon }) => (

--- a/src/views/Onboarding/screens/environment/__tests__/screens.test.tsx
+++ b/src/views/Onboarding/screens/environment/__tests__/screens.test.tsx
@@ -10,15 +10,17 @@ describe('WhatIsCohort360', () => {
   it('presents the tool', () => {
     render(<WhatIsCohort360 />)
     expect(screen.getByRole('heading')).toHaveTextContent("Qu'est-ce que Cohort360 ?")
-    expect(screen.getByText('visualiser les données de groupes de patients')).toBeInTheDocument()
+    expect(
+      screen.getByText(/outil de datavisualisation visant à constituer des cohortes de patients/)
+    ).toBeInTheDocument()
   })
 })
 
 describe('WhatIsEds', () => {
   it('links to the EDS site in a new tab, safely', () => {
     render(<WhatIsEds />)
-    const link = screen.getByRole('link', { name: /En savoir plus sur l'EDS/ })
-    expect(link).toHaveAttribute('href', 'https://eds.aphp.fr/')
+    const link = screen.getByRole('link', { name: /Entrepôt de Données de Santé/ })
+    expect(link).toHaveAttribute('href', 'https://panorama.eds.aphp.fr/explorer-les-donnees')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
   })

--- a/src/views/Onboarding/screens/handson/KeyFeatures.tsx
+++ b/src/views/Onboarding/screens/handson/KeyFeatures.tsx
@@ -46,7 +46,7 @@ const KeyFeatures = () => {
           </Typography>
           <Typography className={classes.sectionText}>
             La fonctionnalité d'export de cohortes sur votre ordinateur (en .csv et en .xlsx) est disponible uniquement
-            pour certaines habilitations et limité à 20 000 patients par export.
+            pour certaines habilitations et limitée à 20 000 patients par export.
           </Typography>
           <FeatureVideo name="export_dataset" label="Exporter des données" />
         </>

--- a/src/views/Onboarding/screens/handson/KeyFeatures.tsx
+++ b/src/views/Onboarding/screens/handson/KeyFeatures.tsx
@@ -14,11 +14,11 @@ const KeyFeatures = () => {
   return (
     <Box>
       <Typography variant="h4" className={classes.title}>
-        Prendre en main Cohort360
+        Prendre en main l'outil
       </Typography>
 
       <Typography variant="h5" className={classes.subTitle}>
-        1 - Créer une cohorte grâce au requêteur
+        Comment utiliser le requêteur ?
       </Typography>
       <Typography className={classes.sectionText}>
         Le requêteur vous permet de <strong>combiner plusieurs critères</strong> (âge, pathologie, période,
@@ -31,26 +31,23 @@ const KeyFeatures = () => {
       <FeatureVideo name="constitution_cohorte" label="Créer une cohorte grâce au requêteur" />
 
       <Typography variant="h5" className={classes.subTitle}>
-        2 - Explorer les données
+        Comment explorer les données ?
       </Typography>
       <Typography className={classes.sectionText}>
-        L'exploration de données vous permet d'accéder aux données associées à un patient ou à différents groupes de
-        patients.
+        Cohort360 comprend un espace d'exploration de données en ligne pour explorer un patient ou un groupe de patient
+        (périmètre).
       </Typography>
       <FeatureVideo name="parcours_patient" label="Explorer les données" />
 
       {!deidentified && (
         <>
           <Typography variant="h5" className={classes.subTitle}>
-            3 - Exporter des données (accès nominatif uniquement)
+            Comment exporter des données ?
           </Typography>
           <Typography className={classes.sectionText}>
-            La fonctionnalité d'export de cohortes en local est disponible uniquement :
+            La fonctionnalité d'export de cohortes sur votre ordinateur (en .csv et en .xlsx) est disponible uniquement
+            pour certaines habilitations et limité à 20 000 patients par export.
           </Typography>
-          <ul className={classes.list}>
-            <li>pour les comptes avec un profil nominatif en périmètre équipe de soin</li>
-            <li>pour les cohortes de moins de 20 000 patients</li>
-          </ul>
           <FeatureVideo name="export_dataset" label="Exporter des données" />
         </>
       )}

--- a/src/views/Onboarding/screens/handson/__tests__/KeyFeatures.test.tsx
+++ b/src/views/Onboarding/screens/handson/__tests__/KeyFeatures.test.tsx
@@ -30,7 +30,7 @@ describe('KeyFeatures (US-3310)', () => {
       '/assets/videos/parcours_patient.mp4',
       '/assets/videos/export_dataset.mp4'
     ])
-    expect(screen.getByText(/Exporter des données/)).toBeInTheDocument()
+    expect(screen.getByText(/Comment exporter des données \?/)).toBeInTheDocument()
   })
 
   it('drops the export video for a pseudonymised access (RG3310.02)', () => {
@@ -39,12 +39,12 @@ describe('KeyFeatures (US-3310)', () => {
       '/assets/videos/constitution_cohorte.mp4',
       '/assets/videos/parcours_patient.mp4'
     ])
-    expect(screen.queryByText(/Exporter des données/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Comment exporter des données \?/)).not.toBeInTheDocument()
   })
 
   it('drops the export video when the access is unknown', () => {
     const { container } = renderKeyFeatures(null)
     expect(videoSources(container)).toHaveLength(2)
-    expect(screen.queryByText(/Exporter des données/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Comment exporter des données \?/)).not.toBeInTheDocument()
   })
 })

--- a/src/views/Onboarding/steps.ts
+++ b/src/views/Onboarding/steps.ts
@@ -60,7 +60,7 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
   {
     key: 'environment',
     label: 'Découvrir votre environnement',
-    summary: 'Apprenez-en plus sur ce qu’est Cohort360 et sur vos accès aux données dans l’outil.',
+    summary: 'Apprenez-en plus sur ce qu’est Cohort360 et sur vos habilitations aux données dans l’outil.',
     icon: MenuBookIcon,
     screens: [
       { key: 'what-is-cohort360', component: WhatIsCohort360 },
@@ -98,7 +98,7 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
   {
     key: 'handson',
     label: "Prendre en main l'outil",
-    summary: 'Explorez l’outil au travers d’une prise en main guidée de 3 fonctionnalités clés.',
+    summary: 'Explorez l’outil au travers d’une prise en main guidée des fonctionnalités clés.',
     icon: FormatListBulletedIcon,
     screens: [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3428

Alignement des textes du parcours d'onboarding sur les maquettes V2.

## Changements réalisés
- Accueil : « vos habilitations aux données », « prise en main guidée des fonctionnalités clés ».
- Qu'est-ce que Cohort360 : nouveau paragraphe de présentation.
- Qu'est-ce que l'EDS : paragraphe révisé, lien vers le panorama de l'EDS posé sur « l'Entrepôt de Données de Santé (EDS) », libellés des familles de données ajustés.
- Règles d'utilisation : « En accédant à Cohort360 », ajout de la liste des textes de référence avec les liens vers les règles d'accès à l'EDS et Légifrance.
- Comprendre votre habilitation : titre et libellés des champs.
- Prise en main : titre, sous-titres sous forme de questions et textes des sections.
- Retrait de `@types/react-router` et `@types/react-router-dom`, restés en v5 alors que react-router est en v7 et fournit ses propres types.

## Impacts
Front.

## Tests réalisés
Tests unitaires mis à jour.

## Risques
Aucun.

