### PR TITLE
fix(export): ne plus ajouter patient__identifier en export regroupé

### DIFF
--- a/src/__tests__/components/ExportTable.test.tsx
+++ b/src/__tests__/components/ExportTable.test.tsx
@@ -63,7 +63,6 @@ const renderTable = (props: Partial<Parameters<typeof ExportTable>[0]> = {}) =>
         compatibilitiesTables={null}
         exportTypeFile="csv"
         oneFile={false}
-        selectedTablesCount={1}
         {...props}
       />
     </AppConfig.Provider>
@@ -106,14 +105,10 @@ describe('ExportTable', () => {
     expect(await screen.findByText(/patient__identifier sera également exportée/)).toBeInTheDocument()
   })
 
-  it("masque la mention de patient__identifier en export regroupé lorsqu'une autre table est sélectionnée", async () => {
-    renderTable({ exportTable: { ...tableInfo, name: 'Patient' }, oneFile: true, selectedTablesCount: 2 })
+  it('masque la mention de patient__identifier en export regroupé', async () => {
+    renderTable({ exportTable: { ...tableInfo, name: 'Patient' }, oneFile: true })
     await screen.findAllByText('Patient')
     expect(screen.queryByText(/patient__identifier sera également exportée/)).not.toBeInTheDocument()
   })
 
-  it('conserve la mention de patient__identifier en export regroupé sur la seule table Patient', async () => {
-    renderTable({ exportTable: { ...tableInfo, name: 'Patient' }, oneFile: true, selectedTablesCount: 1 })
-    expect(await screen.findByText(/patient__identifier sera également exportée/)).toBeInTheDocument()
-  })
 })

--- a/src/__tests__/services/serviceExportCohort.test.ts
+++ b/src/__tests__/services/serviceExportCohort.test.ts
@@ -222,7 +222,7 @@ describe('serviceExportCohort.postExportCohort', () => {
     expect(tableNames.filter((name) => name === 'patient__identifier')).toHaveLength(1)
   })
 
-  it("n'ajoute pas patient__identifier en export regroupé quand une autre table est sélectionnée", async () => {
+  it("n'ajoute pas patient__identifier en export regroupé", async () => {
     mockPost.mockResolvedValue(asAxios({ uuid: 'exp-5' }))
     await postExportCohort({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -242,7 +242,7 @@ describe('serviceExportCohort.postExportCohort', () => {
     expect(tableNames).toEqual(['Patient', 'visit_occurrence'])
   })
 
-  it('ajoute patient__identifier en export regroupé quand Patient est la seule table sélectionnée', async () => {
+  it("n'ajoute pas patient__identifier en export regroupé même si Patient est la seule table", async () => {
     mockPost.mockResolvedValue(asAxios({ uuid: 'exp-6' }))
     await postExportCohort({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -257,7 +257,7 @@ describe('serviceExportCohort.postExportCohort', () => {
     })
     const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string }[] }
     const tableNames = payload.export_tables.map((table) => table.table_name)
-    expect(tableNames).toEqual(['Patient', 'patient__identifier'])
+    expect(tableNames).toEqual(['Patient'])
   })
 
   it('omet fhir_filter quand aucun filtre n’est fourni', async () => {

--- a/src/pages/ExportRequest/components/ExportForm/index.tsx
+++ b/src/pages/ExportRequest/components/ExportForm/index.tsx
@@ -388,7 +388,6 @@ const ExportForm: React.FC = () => {
         compatibilitiesTables={compatibilitiesTables}
         exportTypeFile={exportTypeFile}
         oneFile={oneFile}
-        selectedTablesCount={tablesSettings.length}
       />
     ))
   }, [
@@ -401,8 +400,7 @@ const ExportForm: React.FC = () => {
     onChangeTableSettings,
     compatibilitiesTables,
     exportTypeFile,
-    oneFile,
-    tablesSettings.length
+    oneFile
   ])
 
   return (

--- a/src/pages/ExportRequest/components/ExportTable/index.tsx
+++ b/src/pages/ExportRequest/components/ExportTable/index.tsx
@@ -60,7 +60,6 @@ type ExportTableProps = {
   compatibilitiesTables: string[] | null
   exportTypeFile: 'xlsx' | 'csv'
   oneFile: boolean
-  selectedTablesCount: number
 }
 
 /**
@@ -103,8 +102,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
   onChangeTableSettings,
   compatibilitiesTables,
   exportTypeFile,
-  oneFile,
-  selectedTablesCount
+  oneFile
 }) => {
   const dispatch = useAppDispatch()
   const userId = useAppSelector((state) => state.me?.id)
@@ -296,7 +294,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
               {']'}
             </Typography>
           </div>
-          {exportTable.name === 'Patient' && (!oneFile || selectedTablesCount === 1) && (
+          {exportTable.name === 'Patient' && !oneFile && (
             <Typography variant="caption" fontStyle="italic" color="#888" sx={{ width: '100%', mt: '4px' }}>
               La sous-table patient__identifier sera également exportée avec la table Patient.
             </Typography>

--- a/src/services/aphp/serviceExportCohort.ts
+++ b/src/services/aphp/serviceExportCohort.ts
@@ -165,9 +165,9 @@ export const postExportCohort = async ({
     //pivot_split_columns : table.pivotSplitColumns,
     pivot_merge_ids: table.pivotMergeIds
   }))
-  // En export regroupé, une sous-table ne partage un lien hamiltonien avec sa table parente que si
-  // celle-ci est seule : au-delà, le dataexporter refuse la jointure sur clé primaire.
-  if (!group_tables || tables.length === 1) {
+  // Le dataexporter refuse la jointure sur clé primaire dès qu'une sous-table est demandée,
+  // celle-ci étant en relation 1-N avec sa table parente.
+  if (!group_tables) {
     const existingTableNames = new Set(export_tables.map((table) => table.table_name))
     tables.forEach((table: TableSetting) => {
       const linkedTables = AUTO_LINKED_TABLES[table.tableName]


### PR DESCRIPTION
## Objectif
Sur `develop`, `patient__identifier` est injecté en export regroupé lorsque `Patient` est la seule table cochée, alors que le dataexporter refuse la jointure sur clé primaire dans ce cas. Aligne `develop` sur le comportement livré en 3.5.1.

Fixes [#3397](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3397)

## Changements réalisés
Cherry-pick de `e5c0e595` depuis `release/3.5.1`. La sous-table n'est plus ajoutée dès que l'export est regroupé, et le libellé sous le bloc `Patient` suit la même condition.

## Impacts
Front, exports.

## Tests réalisés
Tests unitaires mis à jour.

## Risques
En export regroupé, l'IPP n'est pas exporté, y compris sur `Patient` seule. La question se reposera à l'identique sur le 3418.
