### PR TITLE
fix(export): bloquer l'export regroupé sur une seule table

### DIFF
--- a/src/__tests__/components/ExportForm.test.tsx
+++ b/src/__tests__/components/ExportForm.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const dispatch = vi.fn()
+vi.mock('state', () => ({ useAppDispatch: () => dispatch }))
+vi.mock('state/warningDialog', () => ({ showDialog: vi.fn((p) => ({ type: 'show', payload: p })) }))
+
+vi.mock('services/aphp/callApi', () => ({
+  fetchExportableCohorts: vi.fn(async () => []),
+  fetchExportableCohort: vi.fn(async () => [{ uuid: 'c1', group_id: 'g1', name: 'Cohorte' }])
+}))
+
+vi.mock('services/aphp/serviceExportCohort', () => ({
+  fetchExportTablesInfo: vi.fn(async () => [
+    { name: 'Patient', columns: [], fhirResourceName: 'Patient', isFhirStandard: true, isOmopStandard: false }
+  ]),
+  fetchExportTablesRelationsInfo: vi.fn(async () => []),
+  postExportCohort: vi.fn(async () => ({ data: {} }))
+}))
+
+vi.mock('pages/ExportRequest/components/exportUtils', () => ({
+  sortTables: (t: unknown[]) => t
+}))
+
+vi.mock('../ExportTable', () => ({ default: () => <div data-testid="export-table" /> }))
+vi.mock('pages/ExportRequest/components/ExportTable', () => ({ default: () => <div data-testid="export-table" /> }))
+
+import ExportForm from 'pages/ExportRequest/components/ExportForm'
+
+const renderForm = () =>
+  render(
+    <MemoryRouter initialEntries={['/export?groupId=g1']}>
+      <ExportForm />
+    </MemoryRouter>
+  )
+
+const fillMotivationAndConditions = () => {
+  fireEvent.change(screen.getByLabelText(/Motif de l'export/), { target: { value: "Export pour l'étude" } })
+  fireEvent.click(screen.getByRole('checkbox', { name: /conditions ci-dessus/i }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ExportForm', () => {
+  it('bloque le regroupement en un seul fichier quand une seule table est sélectionnée', async () => {
+    renderForm()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Confirmer' })).toBeInTheDocument())
+
+    fillMotivationAndConditions()
+    fireEvent.click(screen.getByRole('checkbox', { name: /Regrouper plusieurs tables en un seul fichier/i }))
+
+    expect(screen.getByRole('button', { name: 'Confirmer' })).toBeDisabled()
+    expect(screen.getByText(/au moins deux tables pour regrouper l'export/i)).toBeInTheDocument()
+  })
+
+  it('autorise l’export d’une seule table hors regroupement', async () => {
+    renderForm()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Confirmer' })).toBeInTheDocument())
+
+    fillMotivationAndConditions()
+
+    expect(screen.getByRole('button', { name: 'Confirmer' })).toBeEnabled()
+    expect(screen.queryByText(/au moins deux tables pour regrouper l'export/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/ExportRequest/components/ExportForm/index.tsx
+++ b/src/pages/ExportRequest/components/ExportForm/index.tsx
@@ -127,6 +127,8 @@ const ExportForm: React.FC = () => {
 
   const limitError = errorTables.some((errorTable) => errorTable.error === Error.ERROR_TABLE_LIMIT)
   const fetchCountError = errorTables.some((errorTable) => errorTable.error === Error.ERROR_FETCH)
+  // Le regroupement en un seul fichier repose sur une jointure : il faut au moins deux tables à relier.
+  const groupedTablesError = oneFile && tablesSettings.filter((tableSetting) => tableSetting.isChecked).length < 2
 
   const _checkExportableCohortID = useCallback(async () => {
     if (cohortID !== null) {
@@ -636,7 +638,12 @@ const ExportForm: React.FC = () => {
               />
               <Button
                 disabled={
-                  conditions === false || motivation === null || error === Error.ERROR_MOTIF || limitError || exporting
+                  conditions === false ||
+                  motivation === null ||
+                  error === Error.ERROR_MOTIF ||
+                  limitError ||
+                  groupedTablesError ||
+                  exporting
                 }
                 onClick={() => {
                   setExporting(true)
@@ -665,6 +672,11 @@ const ExportForm: React.FC = () => {
             {limitError && (
               <CustomAlert severity="error">
                 Merci d'indiquer des tables qui respectent la limite de lignes autorisées.
+              </CustomAlert>
+            )}
+            {groupedTablesError && (
+              <CustomAlert severity="error">
+                Merci de sélectionner au moins deux tables pour regrouper l'export en un seul fichier.
               </CustomAlert>
             )}
           </Grid>


### PR DESCRIPTION
## Objectif

Un export « Regrouper plusieurs tables en un seul fichier » portant sur une seule table part en échec côté dataexporter :

```
JoinOnPrimaryKeyTablesAreNotRelated: Join on primary key requested is not possible:
the requested tables () are not related.
```

Le formulaire laissait soumettre ce cas, l'utilisateur ne découvrait l'échec que par mail.

Fixes [#3397](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3397)

## Changements réalisés

Le bouton de confirmation est désactivé quand le regroupement est coché et que moins de deux tables sont sélectionnées, avec une alerte reprenant le format des messages existants du formulaire.

## Impacts

Front, page de demande d'export. Le cas d'une table seule sans regroupement reste inchangé.

## Tests réalisés

Tests unitaires ajoutés sur le formulaire, pour le blocage du regroupement à une table et pour la non-régression de l'export simple.

## Risques

Le seuil de deux tables est déduit du log du dataexporter, où la liste des tables à relier ressort vide avec `Patient` seule. À confirmer en recette qu'un export regroupé sur exactement deux tables aboutit.

Le back reste permissif : `csv_exporter.validate` et `base_exporter.validate` ne contrôlent pas `export_tables`, un appel direct à l'API passe toujours.
