### PR TITLE
fix(export): laisse le back ajouter patient__identifier

### DIFF
--- a/src/__tests__/components/ExportTable.test.tsx
+++ b/src/__tests__/components/ExportTable.test.tsx
@@ -105,10 +105,10 @@ describe('ExportTable', () => {
     expect(await screen.findByText(/patient__identifier sera également exportée/)).toBeInTheDocument()
   })
 
-  it('masque la mention de patient__identifier en export regroupé', async () => {
+  it('signale la sous-table patient__identifier aussi en export regroupé', async () => {
     renderTable({ exportTable: { ...tableInfo, name: 'Patient' }, oneFile: true })
     await screen.findAllByText('Patient')
-    expect(screen.queryByText(/patient__identifier sera également exportée/)).not.toBeInTheDocument()
+    expect(screen.getByText(/patient__identifier sera également exportée/)).toBeInTheDocument()
   })
 
 })

--- a/src/__tests__/services/serviceExportCohort.test.ts
+++ b/src/__tests__/services/serviceExportCohort.test.ts
@@ -180,7 +180,7 @@ describe('serviceExportCohort.postExportCohort', () => {
     )
   })
 
-  it('ajoute automatiquement patient__identifier quand Patient est sélectionné', async () => {
+  it('envoie uniquement les tables sélectionnées', async () => {
     mockPost.mockResolvedValue(asAxios({ uuid: 'exp-3' }))
     await postExportCohort({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -190,74 +190,13 @@ describe('serviceExportCohort.postExportCohort', () => {
       outputFormat: 'csv',
       tables: [
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any
-      ]
-    })
-    const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string; cohort_result_source: string }[] }
-    const tableNames = payload.export_tables.map((table) => table.table_name)
-    expect(tableNames).toEqual(['Patient', 'patient__identifier'])
-    payload.export_tables.forEach((table) => {
-      expect(table.cohort_result_source).toBe('cohort-3')
-    })
-  })
-
-  it('ne duplique pas une sous-table liée déjà sélectionnée', async () => {
-    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-4' }))
-    await postExportCohort({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cohortId: { uuid: 'cohort-4' } as any,
-      motivation: 'analyse',
-      group_tables: false,
-      outputFormat: 'csv',
-      tables: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { tableName: 'patient__identifier', respectTableRelationships: true, columns: null, fhirFilter: null } as any
-      ]
-    })
-    const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string }[] }
-    const tableNames = payload.export_tables.map((table) => table.table_name)
-    expect(tableNames).toEqual(['Patient', 'patient__identifier'])
-    expect(tableNames.filter((name) => name === 'patient__identifier')).toHaveLength(1)
-  })
-
-  it("n'ajoute pas patient__identifier en export regroupé", async () => {
-    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-5' }))
-    await postExportCohort({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cohortId: { uuid: 'cohort-5' } as any,
-      motivation: 'analyse',
-      group_tables: true,
-      outputFormat: 'csv',
-      tables: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         { tableName: 'visit_occurrence', respectTableRelationships: true, columns: null, fhirFilter: null } as any
       ]
     })
     const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string }[] }
-    const tableNames = payload.export_tables.map((table) => table.table_name)
-    expect(tableNames).toEqual(['Patient', 'visit_occurrence'])
-  })
-
-  it("n'ajoute pas patient__identifier en export regroupé même si Patient est la seule table", async () => {
-    mockPost.mockResolvedValue(asAxios({ uuid: 'exp-6' }))
-    await postExportCohort({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cohortId: { uuid: 'cohort-6' } as any,
-      motivation: 'analyse',
-      group_tables: true,
-      outputFormat: 'csv',
-      tables: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { tableName: 'Patient', respectTableRelationships: true, columns: null, fhirFilter: null } as any
-      ]
-    })
-    const payload = mockPost.mock.calls[0][1] as { export_tables: { table_name: string }[] }
-    const tableNames = payload.export_tables.map((table) => table.table_name)
-    expect(tableNames).toEqual(['Patient'])
+    expect(payload.export_tables.map((table) => table.table_name)).toEqual(['Patient', 'visit_occurrence'])
   })
 
   it('omet fhir_filter quand aucun filtre n’est fourni', async () => {

--- a/src/pages/ExportRequest/components/ExportTable/index.tsx
+++ b/src/pages/ExportRequest/components/ExportTable/index.tsx
@@ -294,7 +294,7 @@ const ExportTable: React.FC<ExportTableProps> = ({
               {']'}
             </Typography>
           </div>
-          {exportTable.name === 'Patient' && !oneFile && (
+          {exportTable.name === 'Patient' && (
             <Typography variant="caption" fontStyle="italic" color="#888" sx={{ width: '100%', mt: '4px' }}>
               La sous-table patient__identifier sera également exportée avec la table Patient.
             </Typography>

--- a/src/services/aphp/serviceExportCohort.ts
+++ b/src/services/aphp/serviceExportCohort.ts
@@ -135,10 +135,6 @@ export const fetchExportsList = async (
   }
 }
 
-const AUTO_LINKED_TABLES: Record<string, string[]> = {
-  Patient: ['patient__identifier']
-}
-
 export const postExportCohort = async ({
   cohortId,
   motivation,
@@ -165,27 +161,6 @@ export const postExportCohort = async ({
     //pivot_split_columns : table.pivotSplitColumns,
     pivot_merge_ids: table.pivotMergeIds
   }))
-  // Le dataexporter refuse la jointure sur clé primaire dès qu'une sous-table est demandée,
-  // celle-ci étant en relation 1-N avec sa table parente.
-  if (!group_tables) {
-    const existingTableNames = new Set(export_tables.map((table) => table.table_name))
-    tables.forEach((table: TableSetting) => {
-      const linkedTables = AUTO_LINKED_TABLES[table.tableName]
-      if (!linkedTables) return
-      linkedTables.forEach((linkedTableName) => {
-        if (existingTableNames.has(linkedTableName)) return
-        existingTableNames.add(linkedTableName)
-        export_tables.push({
-          table_name: linkedTableName,
-          cohort_result_source: cohortId?.uuid,
-          respect_table_relationships: table.respectTableRelationships,
-          columns: null,
-          pivot_merge_columns: undefined,
-          pivot_merge_ids: undefined
-        })
-      })
-    })
-  }
 
   return await apiBackend.post<Export>('/exports/', {
     motivation,


### PR DESCRIPTION
## Objectif
[3397](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3397) : l'ajout de `patient__identifier` passe côté back, qui joint le filtre restreignant la table aux IPP officiels.

## Changements réalisés
`postExportCohort` n'envoie plus que les tables cochées. Le libellé du bloc `Patient` reste affiché et ne dépend plus du mode d'export, la sous-table partant désormais dans tous les cas.

## Impacts
Front. Le payload `/exports/` ne contient plus la sous-table injectée par le client.

## Tests réalisés
Tests unitaires mis à jour sur le service d'export et sur le libellé.

## Risques
À merger une fois la qualification du back concluante, PR aphp/Cohort360-Back-end#590.
