### PR TITLE
feat(maintenance): laisser passer les utilisateurs exemptés

### DIFF
--- a/src/components/CreationCohort/ControlPanel/ControlPanel.tsx
+++ b/src/components/CreationCohort/ControlPanel/ControlPanel.tsx
@@ -64,6 +64,7 @@ import { hasStageDetails } from '../DiagramView/components/CriteriaCount'
 import { isRequestFinished } from './utils'
 import { useCountReconciliation } from './useCountReconciliation'
 import { CriteriaType } from 'types/requestCriterias'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 const ControlPanel: React.FC<{
   canExecuteJson: boolean
@@ -111,7 +112,7 @@ const ControlPanel: React.FC<{
   )
   const [prevCountDisplay, setPrevCountDisplay] = useState<number | undefined>()
 
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
 
   const cohortLimit = appConfig.features.cohort.shortCohortLimit
 

--- a/src/components/CreationCohort/DiagramView/components/LogicalOperator/index.tsx
+++ b/src/components/CreationCohort/DiagramView/components/LogicalOperator/index.tsx
@@ -32,6 +32,7 @@ import { DndContext, DragEndEvent, PointerSensor, UniqueIdentifier, useSensor, u
 import { SortableContext } from '@dnd-kit/sortable'
 import Draggable from 'components/ui/DragAndDrop/Draggable'
 import { snapVerticalCenterToCursor } from 'components/ui/DragAndDrop/snapVerticalCenterToCursor'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 const OVERFLOW = 1
 const HEADER = 74
@@ -342,7 +343,7 @@ const LogicalOperator: React.FC = () => {
     [request.selectedCriteria]
   )
 
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
 
   return (
     <>

--- a/src/components/CreationCohort/DiagramView/components/PopulationCard/components/ModalRightError.tsx
+++ b/src/components/CreationCohort/DiagramView/components/PopulationCard/components/ModalRightError.tsx
@@ -8,14 +8,14 @@ import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
 
-import { useAppSelector } from 'state'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 type ModalRightErrorProps = {
   open: boolean
   handleClose: () => void
 }
 const ModalRightError: React.FC<ModalRightErrorProps> = ({ open, handleClose }) => {
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
 
   const navigate = useNavigate()
 

--- a/src/components/CreationCohort/DiagramView/components/TemporalConstraintCard/TemporalConstraintCard.tsx
+++ b/src/components/CreationCohort/DiagramView/components/TemporalConstraintCard/TemporalConstraintCard.tsx
@@ -10,13 +10,14 @@ import useStyles from './styles'
 import { TemporalConstraintsKind } from 'types'
 import { getSelectableGroups } from 'utils/temporalConstraints'
 import { CriteriaType } from 'types/requestCriterias'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 const TemporalConstraint: React.FC = () => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const [temporalConstraintExist, setTemporalConstraintExist] = useState(false)
   const [disableTemporalConstraint, setDisableTemporalConstraint] = useState(false)
 
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
   const {
     criteriaGroup = [],
     temporalConstraints,

--- a/src/components/CreationCohort/DiagramView/index.tsx
+++ b/src/components/CreationCohort/DiagramView/index.tsx
@@ -18,6 +18,7 @@ import CustomAlert from 'components/ui/Alert'
 import { HiddenScrollBar } from 'components/ui/Scrollbar/styles'
 import { CriteriaType, ViewMode } from 'types/requestCriterias'
 import { PinkSwitch } from './styles'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 interface DiagramViewWithAjvProps {
   isValidJson: (canExecuteJson: boolean) => void
@@ -27,7 +28,7 @@ const DiagramView: React.FC<DiagramViewWithAjvProps> = ({ isValidJson }) => {
   const dispatch = useAppDispatch()
   const { selectedPopulation = [], ...requestState } = useAppSelector((state) => state.cohortCreation.request || {})
   const { rights } = useAppSelector((state) => state.scope || {})
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active || false)
+  const maintenanceIsActive = useMaintenanceIsActive()
   const [openDrawer, setOpenDrawer] = useState(false)
   const [rightsError, setRightsError] = useState(false)
   const [selectedCodes, setSelectedCodes] = useState<Hierarchy<ScopeElement>[]>([])

--- a/src/components/ExplorationBoard/CriteriasSection/index.tsx
+++ b/src/components/ExplorationBoard/CriteriasSection/index.tsx
@@ -3,12 +3,12 @@ import { AccordionDetails, AccordionSummary, Grid, Tooltip, Typography } from '@
 import { FilterKeys, FilterValue, SearchCriteriaKeys } from 'types/searchCriterias'
 import SaveFilter from './SaveFilter'
 import Truncated from 'components/ui/Truncated'
-import { useAppSelector } from 'state'
 import { DisplayOptions, GAP } from 'types/exploration'
 import AccordionWrapper from 'components/ui/Accordion'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { ChipWrapper } from 'components/ui/Chip/styles'
 import CancelIcon from '@mui/icons-material/Cancel'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 type Criteria = {
   value: FilterValue
@@ -25,7 +25,7 @@ type CriteriasSectionProps = {
 }
 
 const CriteriasSection = ({ value, displayOptions, onDelete, onSaveFilters }: CriteriasSectionProps) => {
-  const maintenanceIsActive = useAppSelector((state) => state.me)?.maintenance?.active
+  const maintenanceIsActive = useMaintenanceIsActive()
 
   const CustomChip = ({ value, category, label, disabled = false }: Criteria) => {
     return (

--- a/src/components/ExplorationBoard/SearchSection/EditSavedFilter.tsx
+++ b/src/components/ExplorationBoard/SearchSection/EditSavedFilter.tsx
@@ -7,8 +7,8 @@ import { SelectedFilter } from 'hooks/filters/useSavedFilters'
 import Select from 'components/ui/Searchbar/Select'
 import { Controller, useForm } from 'react-hook-form'
 import ExplorationFilters from '../Filters'
-import { useAppSelector } from 'state'
 import { AdditionalInfo } from 'types/exploration'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 type EditSavedFilterProps = {
   open: boolean
@@ -19,7 +19,7 @@ type EditSavedFilterProps = {
 }
 
 const EditSavedFilter = ({ open, criteria, infos, onEdit, onClose }: EditSavedFilterProps) => {
-  const maintenanceIsActive = useAppSelector((state) => state.me)?.maintenance?.active
+  const maintenanceIsActive = useMaintenanceIsActive()
   const [isError, setIsError] = useState(false)
   const [hasChanged, setHasChanged] = useState(false)
   const [form, setForm] = useState(criteria.filterParams.filters)

--- a/src/components/ExplorationBoard/SearchSection/SavedFilters.tsx
+++ b/src/components/ExplorationBoard/SearchSection/SavedFilters.tsx
@@ -6,9 +6,9 @@ import { DeleteOutline, SavedSearch, Visibility } from '@mui/icons-material'
 import { SelectedFilter } from 'hooks/filters/useSavedFilters'
 import { Filters, SavedFiltersResults, SearchCriterias } from 'types/searchCriterias'
 import EditSavedFilter from './EditSavedFilter'
-import { useAppSelector } from 'state'
 import { AdditionalInfo } from 'types/exploration'
 import Button from 'components/ui/Button'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 type SavedFiltersProps = {
   selectedFilter: SelectedFilter<Filters> | null
@@ -35,7 +35,7 @@ const SavedFilters = ({
   const [toggleDeleteModal, setToggleDeleteModal] = useState(false)
   const [toggleDisplayModal, setToggleDisplayModal] = useState(false)
   const [selectedItems, setSelectedItems] = useState<string[]>([])
-  const maintenanceIsActive = useAppSelector((state) => state.me)?.maintenance?.active
+  const maintenanceIsActive = useMaintenanceIsActive()
 
   const asListItems = useMemo(
     () =>

--- a/src/components/Researches/ProjectsList.tsx
+++ b/src/components/Researches/ProjectsList.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
-import { useAppSelector } from 'state'
 
 import { Grid, Typography } from '@mui/material'
 import AddOrEditItem from './Modals/AddOrEditItem'
@@ -27,10 +26,11 @@ import {
 } from 'utils/explorationUtils'
 import { ExplorationsSearchParams } from 'types/cohorts'
 import { plural } from 'utils/string'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 const ProjectsList = () => {
   const navigate = useNavigate()
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
   const [searchParams, setSearchParams] = useSearchParams()
   const { searchInput, startDate, endDate, orderBy, orderDirection } = getFoldersSearchParams(searchParams)
   const [order, setOrder] = useState<OrderBy>({ orderBy, orderDirection })

--- a/src/components/Researches/RequestsList.tsx
+++ b/src/components/Researches/RequestsList.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router'
-import { useAppDispatch, useAppSelector } from 'state'
+import { useAppDispatch } from 'state'
 import { resetCohortCreation } from 'state/cohortCreation'
 import { setSelectedProject } from 'state/project'
 
@@ -38,6 +38,7 @@ import {
   getRequestsConfirmDeletionTitle,
   getRequestsSearchParams
 } from 'utils/explorationUtils'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 type RequestsListProps = {
   simplified?: boolean
@@ -50,7 +51,7 @@ const RequestsList = ({ simplified = false, rowsPerPage = 20 }: RequestsListProp
   const { projectId } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
   const { searchInput, startDate, endDate, page, orderBy, orderDirection } = getRequestsSearchParams(searchParams)
-  const maintenanceIsActive = useAppSelector((state) => state?.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
 
   const [paramsReady, setParamsReady] = useState(false)
   const [deleteMode, setDeleteMode] = useState(false)

--- a/src/components/Routes/LeftSideBar/LeftSideBar.tsx
+++ b/src/components/Routes/LeftSideBar/LeftSideBar.tsx
@@ -45,6 +45,7 @@ import versionInfo from 'data/version.json'
 import Impersonation from 'components/Impersonation'
 import ShimmerBadge from 'components/ui/ShimmerBadge'
 import { AppConfig } from 'config'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 const smallDrawerWidth = 52
 const largeDrawerWidth = 260
@@ -59,7 +60,7 @@ const LeftSideBar: React.FC<{ open?: boolean }> = (props) => {
   const practitioner = useAppSelector((state) => state.me)
   const open = useAppSelector((state) => state.drawer)
   const cohortCreation = useAppSelector((state) => state.cohortCreation)
-  const maintenanceIsActive = practitioner?.maintenance?.active
+  const maintenanceIsActive = useMaintenanceIsActive()
   // v-- just for zoom transition..
   const [allreadyOpen, setAllreadyOpen] = useState(false)
 

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -33,6 +33,7 @@ import { AppConfig } from 'config'
 import { Cohort } from 'types'
 import { URLS } from 'types/exploration'
 import Button from 'components/ui/Button'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 type TopBarProps = {
   context: URLS
@@ -51,7 +52,7 @@ const TopBar: React.FC<TopBarProps> = ({ context, patientsNb, access }) => {
   const navigate = useNavigate()
 
   const appConfig = useContext(AppConfig)
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
   const dashboard = useAppSelector((state) => state.exploredCohort)
 
   const [openModal, setOpenModal] = useState<'' | 'edit' | 'delete' | 'sample'>('')

--- a/src/hooks/maintenance/__tests__/useMaintenanceIsActive.test.tsx
+++ b/src/hooks/maintenance/__tests__/useMaintenanceIsActive.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const { mockUseAppSelector } = vi.hoisted(() => ({
+  mockUseAppSelector: vi.fn()
+}))
+
+vi.mock('state', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useAppSelector: (selector: any) => mockUseAppSelector(selector)
+}))
+
+import useMaintenanceIsActive from '../useMaintenanceIsActive'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderWith = (me: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockUseAppSelector.mockImplementation((selector: any) => selector({ me }))
+  return renderHook(() => useMaintenanceIsActive()).result.current
+}
+
+describe('useMaintenanceIsActive', () => {
+  it('est inactif sans maintenance', () => {
+    expect(renderWith(null)).toBe(false)
+    expect(renderWith({})).toBe(false)
+    expect(renderWith({ maintenance: { active: false, type: 'partial' } })).toBe(false)
+  })
+
+  it('est actif pour un utilisateur non exempté', () => {
+    expect(renderWith({ maintenance: { active: true, type: 'partial' } })).toBe(true)
+    expect(renderWith({ maintenance: { active: true, type: 'partial' }, maintenanceExempted: false })).toBe(true)
+  })
+
+  it('laisse passer un utilisateur exempté pendant une maintenance partielle', () => {
+    expect(renderWith({ maintenance: { active: true, type: 'partial' }, maintenanceExempted: true })).toBe(false)
+  })
+
+  it('reste actif pour un utilisateur exempté pendant une maintenance complète', () => {
+    expect(renderWith({ maintenance: { active: true, type: 'full' }, maintenanceExempted: true })).toBe(true)
+  })
+})

--- a/src/hooks/maintenance/useMaintenanceIsActive.ts
+++ b/src/hooks/maintenance/useMaintenanceIsActive.ts
@@ -1,0 +1,12 @@
+import { useAppSelector } from 'state'
+
+// L'exemption, tenue côté back, ne vaut que pour la maintenance partielle.
+const useMaintenanceIsActive = () => {
+  const maintenance = useAppSelector((state) => state.me?.maintenance)
+  const exempted = useAppSelector((state) => state.me?.maintenanceExempted ?? false)
+
+  if (!maintenance?.active) return false
+  return !(exempted && maintenance.type === 'partial')
+}
+
+export default useMaintenanceIsActive

--- a/src/hooks/researches/useCohortListController.tsx
+++ b/src/hooks/researches/useCohortListController.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState, useContext } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
-import { useAppSelector } from 'state'
 import { AppConfig } from 'config'
 
 import { checkSearchParamsErrors, getCohortsSearchParams, removeFromSearchParams } from 'utils/explorationUtils'
 import { selectFiltersAsArray } from 'utils/filters'
 import { CohortsFilters, OrderBy, FilterKeys } from 'types/searchCriterias'
 import { CohortsType, ExplorationsSearchParams } from 'types/cohorts'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 type CohortListControllerParams<TItem> = {
   useData: (args: {
@@ -29,7 +29,7 @@ const useCohortListController = <TItem,>({
   simplified = false
 }: CohortListControllerParams<TItem>) => {
   const navigate = useNavigate()
-  const maintenanceIsActive = useAppSelector((s) => s?.me?.maintenance?.active ?? false)
+  const maintenanceIsActive = useMaintenanceIsActive()
   const appConfig = useContext(AppConfig)
 
   const [searchParams, setSearchParams] = useSearchParams()

--- a/src/pages/Export/index.tsx
+++ b/src/pages/Export/index.tsx
@@ -24,6 +24,7 @@ import Button from 'components/ui/Button'
 import AddIcon from '@mui/icons-material/Add'
 import PageContainer from 'components/ui/PageContainer'
 import WaitingPopup from 'views/WaitingPopup/WaitingPopup'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 const RESULTS_PER_PAGE = 20
 
@@ -46,7 +47,7 @@ const Export = () => {
   const user = useAppSelector((state) => state.me?.impersonation?.username ?? state.me?.userName) ?? ''
   const deidentified = useAppSelector((state) => state.me?.deidentified)
   const [exportList, setExportList] = useState<Back_API_Response<ExportList> | null>(null)
-  const maintenanceIsActive = useAppSelector((state) => state.me?.maintenance?.active) ?? false
+  const maintenanceIsActive = useMaintenanceIsActive()
   const [loadingStatus, setLoadingStatus] = useState(LoadingStatus.FETCHING)
   const [downloading, setDownloading] = useState<boolean | null>(false)
   const [searchParams, setSearchParams] = useSearchParams()

--- a/src/state/me.ts
+++ b/src/state/me.ts
@@ -50,6 +50,8 @@ export type MeState = null | {
   }
   /** Impersonated user information */
   impersonation?: User
+  /** Whether the user is exempted from partial maintenance */
+  maintenanceExempted?: boolean
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export type MaintenanceInfo = {
   type: string
   message: string
   is_data_saved_message_hidden: boolean
+  user_exempted?: boolean
 }
 
 export type FHIR_API_Response<T extends Resource> = T | OperationOutcome

--- a/src/views/Login/Login.tsx
+++ b/src/views/Login/Login.tsx
@@ -181,7 +181,8 @@ const Login = () => {
           deidentified: nominativeGroupsIds.length === 0,
           lastConnection,
           maintenance,
-          accessExpirations
+          accessExpirations,
+          maintenanceExempted: maintenance.user_exempted ?? false
         }
         dispatch(loginAction(loginState))
         // The login payload already carries the server truth, so the gate reads it without a resync.

--- a/src/views/Welcome/Welcome.tsx
+++ b/src/views/Welcome/Welcome.tsx
@@ -27,6 +27,7 @@ import Markdown from 'react-markdown'
 import { getBannerMessageLevel, sortContent } from 'data/infoMessage'
 import { plural } from 'utils/string'
 import { AppConfig } from 'config'
+import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
 
 const Welcome = () => {
   const { classes } = useStyles()
@@ -45,7 +46,7 @@ const Welcome = () => {
   const maintenancePopupInitialized = useRef(false)
 
   const accessExpirations: AccessExpiration[] = meState?.accessExpirations ?? []
-  const maintenanceIsActive = meState?.maintenance?.active
+  const maintenanceIsActive = useMaintenanceIsActive()
 
   const lastConnection = practitioner?.lastConnection
     ? moment(practitioner.lastConnection).format('[Dernière connexion : ]ddd DD MMMM YYYY[, à ]HH:mm')


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3349

Rendre l'application utilisable normalement, pendant une maintenance partielle, pour les utilisateurs exemptés côté back.

## Changements réalisés
- `useMaintenanceIsActive` centralise la lecture de l'état de maintenance et remplace les lectures directes de `state.me.maintenance.active`.
- L'exemption est stockée dans `me` au login depuis `/maintenances/next/`, hors du payload de maintenance pour survivre aux notifications WebSocket.

## Impacts
Front. Dépend de la PR back https://github.com/aphp/Cohort360-Back-end/pull/592.

## Tests réalisés
Tests ajoutés sur le hook, suite existante rejouée.

## Risques
L'écran bloquant de la maintenance complète est inchangé, l'exemption ne s'applique qu'au type `partial`.