### PR TITLE
chore(github): demande la review de l'équipe design et produit sur chaque PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aphp/i-d-design-et-produit @aphp/cohort360


### PR DESCRIPTION
## Objectif
Faire en sorte que toute PR ouverte sur ce dépôt demande automatiquement une review, sans avoir à désigner un relecteur à la main.

## Changements réalisés
Ajout de `.github/CODEOWNERS` qui déclare les équipes `i-d-design-et-produit` et `cohort360` propriétaires de l'ensemble du dépôt.

## Impacts
Aucun code. Les deux équipes sont sollicitées à l'ouverture de chaque PR non draft, à partir du moment où le fichier est présent sur la branche de base.

## Tests réalisés
Sans objet.

## Risques
La demande de review n'est pas bloquante, aucune protection de branche n'exige l'approbation des code owners.