### PR TITLE
fix(onboarding): fige la barre de défilement et remonte en haut à chaque écran

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -6,6 +6,9 @@ import '@testing-library/jest-dom/vitest'
 // ajoute les méthodes react-testing-library à Vitest pour l'autocompletion
 expect.extend(matchers)
 
+// jsdom ne sait pas défiler
+window.scrollTo = () => undefined
+
 afterEach(() => {
   // Après chaque test, on peut executer des fonctions au besoin
   cleanup()

--- a/src/views/Onboarding/Onboarding.tsx
+++ b/src/views/Onboarding/Onboarding.tsx
@@ -1,10 +1,10 @@
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded'
 import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
-import { Button, Typography } from '@mui/material'
+import { Button, GlobalStyles, Typography } from '@mui/material'
 import logo from 'assets/images/logo-login.png'
 import useOnboardingEnabled from 'hooks/onboarding/useOnboardingEnabled'
 import useOnboardingStatus from 'hooks/onboarding/useOnboardingStatus'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Navigate } from 'react-router'
 
 import { OnboardingProvider, useOnboarding } from './OnboardingContext'
@@ -20,10 +20,25 @@ const PROGRESS_ERROR_MESSAGE =
 
 const OnboardingLayout = () => {
   const { classes, cx } = useStyles()
-  const { screen, currentStep, screenConfig, stepProgress, primaryLabel, canProceed, saving, error, goNext, goBack } =
-    useOnboarding()
+  const {
+    screen,
+    currentStep,
+    subStep,
+    screenConfig,
+    stepProgress,
+    primaryLabel,
+    canProceed,
+    saving,
+    error,
+    goNext,
+    goBack
+  } = useOnboarding()
 
   const ActiveScreen = screenConfig?.component
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [screen, currentStep, subStep])
 
   const header = (
     <>
@@ -58,30 +73,34 @@ const OnboardingLayout = () => {
   )
 
   return (
-    <WizardShell
-      header={header}
-      steps={ONBOARDING_STEPS}
-      activeStep={screen === 'welcome' ? -1 : currentStep}
-      stepProgress={stepProgress}
-      layout={screenConfig?.layout}
-      footer={footer}
-    >
-      {screen === 'welcome' ? (
-        <WelcomeScreen />
-      ) : (
-        ActiveScreen && (
-          <>
-            {screenConfig?.tag && <ScreenTag label={screenConfig.tag} />}
-            <ActiveScreen />
-          </>
-        )
-      )}
-      {error && (
-        <Typography role="alert" className={classes.error}>
-          {screenConfig?.primaryAction?.errorMessage ?? PROGRESS_ERROR_MESSAGE}
-        </Typography>
-      )}
-    </WizardShell>
+    <>
+      {/* Scrollbar always on, so screens do not shift sideways when the content grows. */}
+      <GlobalStyles styles={{ html: { overflowY: 'scroll' } }} />
+      <WizardShell
+        header={header}
+        steps={ONBOARDING_STEPS}
+        activeStep={screen === 'welcome' ? -1 : currentStep}
+        stepProgress={stepProgress}
+        layout={screenConfig?.layout}
+        footer={footer}
+      >
+        {screen === 'welcome' ? (
+          <WelcomeScreen />
+        ) : (
+          ActiveScreen && (
+            <>
+              {screenConfig?.tag && <ScreenTag label={screenConfig.tag} />}
+              <ActiveScreen />
+            </>
+          )
+        )}
+        {error && (
+          <Typography role="alert" className={classes.error}>
+            {screenConfig?.primaryAction?.errorMessage ?? PROGRESS_ERROR_MESSAGE}
+          </Typography>
+        )}
+      </WizardShell>
+    </>
   )
 }
 

--- a/src/views/Onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/Onboarding/__tests__/Onboarding.test.tsx
@@ -119,6 +119,18 @@ describe('Onboarding page', () => {
     await waitFor(() => expect(signCharter).toHaveBeenCalledTimes(1))
   })
 
+  it('goes back to the top of the page on each screen change', async () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo')
+    const user = userEvent.setup()
+    renderAt({ ...baseStatus, onboarding_step: 1 })
+    scrollTo.mockClear()
+
+    await user.click(screen.getByRole('button', { name: /Continuer/ }))
+    expect(scrollTo).toHaveBeenCalledWith(0, 0)
+
+    scrollTo.mockRestore()
+  })
+
   it('closes the journey on the guided tour, with a button to the application', () => {
     renderAt({ ...baseStatus, onboarding_step: 2 }, { deidentified: false } as MeState)
     expect(screen.getByRole('heading', { name: "Prendre en main l'outil" })).toBeInTheDocument()


### PR DESCRIPTION
## Objectif

Related to https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3431

Le parcours d'onboarding se décale latéralement quand la barre de défilement apparaît ou disparaît d'un écran à l'autre, et on garde la position de scroll en changeant d'étape.

## Changements réalisés
Barre de défilement forcée sur la vue Onboarding, et retour en haut de page à chaque changement d'écran.

## Impacts
Front, vue Onboarding uniquement.

## Tests réalisés
Test unitaire ajouté sur le retour en haut de page.

## Risques
La barre étant forcée sur `html`, le verrou de scroll des menus MUI (qui agit sur `body`) ne bloque plus le défilement en arrière-plan pendant le parcours.


