### PR TITLE
fix(onboarding): remplace les vidéos YouTube par le tutoriel hébergé par l'AP-HP

### DIFF
--- a/src/views/Onboarding/FeatureVideo.tsx
+++ b/src/views/Onboarding/FeatureVideo.tsx
@@ -2,28 +2,26 @@ import React from 'react'
 
 import useStyles from './styles'
 
-// Domaine sans cookie : rien n'est déposé tant que la vidéo n'est pas lancée.
-const EMBED_PATH = 'https://www.youtube-nocookie.com/embed'
+const TUTORIAL_URL = 'https://formaphp.fr/documents/orbisetmoi/Tutoriels_Video/Cohort360_v0.mp4'
 
 type Props = {
-  /** Identifiant de la vidéo sur la chaîne Cohort360. */
-  videoId: string
+  /** Position de départ du chapitre dans le tutoriel, en secondes. */
+  startAt: number
   /** Described to assistive technologies, which cannot read the video. */
   label: string
 }
 
-const FeatureVideo = ({ videoId, label }: Props) => {
+const FeatureVideo = ({ startAt, label }: Props) => {
   const { classes } = useStyles()
 
   return (
-    <iframe
+    <video
       className={classes.video}
-      src={`${EMBED_PATH}/${videoId}`}
-      title={label}
-      loading="lazy"
-      referrerPolicy="strict-origin-when-cross-origin"
-      allow="encrypted-media; picture-in-picture"
-      allowFullScreen
+      src={`${TUTORIAL_URL}#t=${startAt}`}
+      aria-label={label}
+      controls
+      playsInline
+      preload="metadata"
     />
   )
 }

--- a/src/views/Onboarding/__tests__/FeatureVideo.test.tsx
+++ b/src/views/Onboarding/__tests__/FeatureVideo.test.tsx
@@ -5,13 +5,16 @@ import { describe, expect, it } from 'vitest'
 import FeatureVideo from '../FeatureVideo'
 
 describe('FeatureVideo', () => {
-  it('embeds the tutorial from the cookieless domain and waits for the section to be reached', () => {
-    const { container } = render(<FeatureVideo videoId="-UjXIK4Svb4" label="Créer une cohorte grâce au requêteur" />)
-    const frame = container.querySelector('iframe')
+  it('starts the tutorial at the requested chapter', () => {
+    const { container } = render(<FeatureVideo startAt={314} label="Explorer les données" />)
+    const player = container.querySelector('video')
 
-    expect(frame).toHaveAttribute('src', 'https://www.youtube-nocookie.com/embed/-UjXIK4Svb4')
-    expect(frame).toHaveAttribute('title', 'Créer une cohorte grâce au requêteur')
-    expect(frame).toHaveAttribute('loading', 'lazy')
-    expect(frame).toHaveAttribute('allowfullscreen')
+    expect(player).toHaveAttribute(
+      'src',
+      'https://formaphp.fr/documents/orbisetmoi/Tutoriels_Video/Cohort360_v0.mp4#t=314'
+    )
+    expect(player).toHaveAttribute('aria-label', 'Explorer les données')
+    expect(player).toHaveAttribute('controls')
+    expect(player).toHaveAttribute('preload', 'metadata')
   })
 })

--- a/src/views/Onboarding/screens/handson/KeyFeatures.tsx
+++ b/src/views/Onboarding/screens/handson/KeyFeatures.tsx
@@ -6,10 +6,11 @@ import { useAppSelector } from 'state'
 import FeatureVideo from '../../FeatureVideo'
 import useStyles from '../../styles'
 
+// Positions des chapitres dans le tutoriel, en secondes.
 const TUTORIALS = {
-  query: '-UjXIK4Svb4',
-  exploration: 'ykyMg_4MVcI',
-  export: '01ZgR9lk_aE'
+  query: 1,
+  exploration: 314,
+  export: 618
 }
 
 const KeyFeatures = () => {
@@ -35,7 +36,7 @@ const KeyFeatures = () => {
           Les données de l'EDS étant en mouvement, votre cohorte correspond à une{' '}
           <strong>« photographie » de vos critères à un instant T</strong> au sein de votre périmètre.
         </Typography>
-        <FeatureVideo videoId={TUTORIALS.query} label="Créer une cohorte grâce au requêteur" />
+        <FeatureVideo startAt={TUTORIALS.query} label="Créer une cohorte grâce au requêteur" />
       </Box>
 
       <Box className={classes.featureSection}>
@@ -46,7 +47,7 @@ const KeyFeatures = () => {
           Cohort360 comprend un espace d'exploration de données en ligne pour explorer un patient ou un groupe de
           patient (périmètre).
         </Typography>
-        <FeatureVideo videoId={TUTORIALS.exploration} label="Explorer les données" />
+        <FeatureVideo startAt={TUTORIALS.exploration} label="Explorer les données d'un patient ou groupe de patients" />
       </Box>
 
       {!deidentified && (
@@ -58,7 +59,7 @@ const KeyFeatures = () => {
             La fonctionnalité d'export de cohortes sur votre ordinateur (en .csv et en .xlsx) est disponible uniquement
             pour certaines habilitations et limitée à 20 000 patients par export.
           </Typography>
-          <FeatureVideo videoId={TUTORIALS.export} label="Exporter des données" />
+          <FeatureVideo startAt={TUTORIALS.export} label="Exporter des données" />
         </Box>
       )}
     </Box>

--- a/src/views/Onboarding/screens/handson/__tests__/KeyFeatures.test.tsx
+++ b/src/views/Onboarding/screens/handson/__tests__/KeyFeatures.test.tsx
@@ -7,8 +7,10 @@ import { describe, expect, it } from 'vitest'
 import meReducer, { type MeState } from 'state/me'
 import KeyFeatures from '../KeyFeatures'
 
+const TUTORIAL_URL = 'https://formaphp.fr/documents/orbisetmoi/Tutoriels_Video/Cohort360_v0.mp4'
+
 const videoSources = (container: HTMLElement) =>
-  Array.from(container.querySelectorAll('iframe')).map((frame) => frame.getAttribute('src'))
+  Array.from(container.querySelectorAll('video')).map((player) => player.getAttribute('src'))
 
 const renderKeyFeatures = (me: MeState) => {
   const store = configureStore({ reducer: { me: meReducer }, preloadedState: { me } })
@@ -25,20 +27,13 @@ const pseudonymised = { displayName: 'Cesar RICHARD', deidentified: true } as Me
 describe('KeyFeatures (US-3310)', () => {
   it('shows the three feature videos to a nominative access (RG3310.01)', () => {
     const { container } = renderKeyFeatures(nominative)
-    expect(videoSources(container)).toEqual([
-      'https://www.youtube-nocookie.com/embed/-UjXIK4Svb4',
-      'https://www.youtube-nocookie.com/embed/ykyMg_4MVcI',
-      'https://www.youtube-nocookie.com/embed/01ZgR9lk_aE'
-    ])
+    expect(videoSources(container)).toEqual([`${TUTORIAL_URL}#t=1`, `${TUTORIAL_URL}#t=314`, `${TUTORIAL_URL}#t=618`])
     expect(screen.getByText(/Comment exporter des données \?/)).toBeInTheDocument()
   })
 
   it('drops the export video for a pseudonymised access (RG3310.02)', () => {
     const { container } = renderKeyFeatures(pseudonymised)
-    expect(videoSources(container)).toEqual([
-      'https://www.youtube-nocookie.com/embed/-UjXIK4Svb4',
-      'https://www.youtube-nocookie.com/embed/ykyMg_4MVcI'
-    ])
+    expect(videoSources(container)).toEqual([`${TUTORIAL_URL}#t=1`, `${TUTORIAL_URL}#t=314`])
     expect(screen.queryByText(/Comment exporter des données \?/)).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Objectif
Les trois vidéos de l'écran « Prendre en main l'outil » de l'onboarding renvoyaient vers YouTube. Elles sont remplacées par le tutoriel hébergé sur formaphp.fr.

## Changements réalisés
`FeatureVideo` embarque un lecteur `<video>` natif sur `https://formaphp.fr/documents/orbisetmoi/Tutoriels_Video/Cohort360_v0.mp4` au lieu d'une iframe YouTube. Les trois sections pointent sur ce même fichier, chacune calée sur son chapitre via un fragment temporel : requêteur à 00'01, exploration à 05'14, export à 10'18.

## Impacts
Front. Plus aucun appel à un domaine tiers depuis l'onboarding. Le fichier est servi par Apache avec `Accept-Ranges: bytes` et son atome `moov` est en tête, le positionnement sur le chapitre se fait donc sans télécharger tout le média.

## Tests réalisés
Tests unitaires mis à jour sur `FeatureVideo` et `KeyFeatures`.

## Risques
La lecture n'a pas de borne de fin : arrivé au bout de son chapitre, le lecteur enchaîne sur le suivant.
