### PR TITLE
feat(cohort): add sensibilite column on cohort table

### DIFF
--- a/src/__tests__/mappers/cohortsTable.test.ts
+++ b/src/__tests__/mappers/cohortsTable.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from 'vitest'
 import { mapCohortsToTable } from 'mappers/cohorts'
 import { getConfig } from 'config'
 import { Cohort, JobStatus } from 'types'
-import { CohortCallbacks } from 'types/cohorts'
+import { CohortCallbacks, ResearchesTableLabels } from 'types/cohorts'
+import { accessType } from 'types/scope'
+import { CellType } from 'types/table'
 
 const appConfig = getConfig()
 
@@ -53,5 +55,68 @@ describe('mappers/cohorts.mapCohortsToTable', () => {
     ]
     const table = mapCohortsToTable(list, false, appConfig, callbacks, [list[0]], undefined, false)
     expect(table.rows).toHaveLength(3)
+  })
+
+  describe('colonne sensibilité (CNIL)', () => {
+    const sensitivityCell = (table: ReturnType<typeof mapCohortsToTable>, uuid: string) =>
+      table.rows[0].find((cell) => cell.id === `${uuid}-sensitivity`)
+
+    it('ajoute une colonne "sensibilité" après le statut', () => {
+      const table = mapCohortsToTable([cohort()], false, appConfig, callbacks, [], undefined, false)
+      const labels = table.columns.map((col) => col.label)
+      expect(labels).toContain(ResearchesTableLabels.SENSITIVITY)
+      expect(labels.indexOf(ResearchesTableLabels.SENSITIVITY)).toBe(
+        labels.indexOf(ResearchesTableLabels.STATUS) + 1
+      )
+    })
+
+    it('rend la cellule sensibilité, y compris en mode simplifié', () => {
+      const table = mapCohortsToTable([cohort()], true, appConfig, callbacks, [], 'req-1', false)
+      expect(sensitivityCell(table, 'c1')?.type).toBe(CellType.TEXT)
+    })
+
+    it('affiche "Nominatif" quand l\'utilisateur a le droit de lecture nominative (read_patient_nomi)', () => {
+      const table = mapCohortsToTable(
+        [cohort({ rights: { read_patient_nomi: true, read_patient_pseudo: true } })],
+        false,
+        appConfig,
+        callbacks,
+        [],
+        undefined,
+        false
+      )
+      expect(sensitivityCell(table, 'c1')?.value).toBe(accessType.NOMINAL)
+    })
+
+    it('affiche "Pseudonymisé" quand seule la lecture pseudonymisée est autorisée', () => {
+      const table = mapCohortsToTable(
+        [cohort({ rights: { read_patient_nomi: false, read_patient_pseudo: true } })],
+        false,
+        appConfig,
+        callbacks,
+        [],
+        undefined,
+        false
+      )
+      expect(sensitivityCell(table, 'c1')?.value).toBe(accessType.PSEUDO)
+    })
+
+    it("ne se fie pas au droit d'export : export nominatif sans lecture nominative => Pseudonymisé", () => {
+      const table = mapCohortsToTable(
+        [cohort({ rights: { export_csv_xlsx_nomi: true, read_patient_nomi: false, read_patient_pseudo: true } })],
+        false,
+        appConfig,
+        callbacks,
+        [],
+        undefined,
+        false
+      )
+      expect(sensitivityCell(table, 'c1')?.value).toBe(accessType.PSEUDO)
+    })
+
+    it('reste indéterminée (valeur vide) quand les droits sont absents', () => {
+      const table = mapCohortsToTable([cohort()], false, appConfig, callbacks, [], undefined, false)
+      expect(sensitivityCell(table, 'c1')?.value).toBe('')
+    })
   })
 })

--- a/src/__tests__/mappers/samplesTable.test.ts
+++ b/src/__tests__/mappers/samplesTable.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi } from 'vitest'
 import { mapSamplesToTable } from 'mappers/samples'
 import { getConfig } from 'config'
 import { Cohort, JobStatus } from 'types'
+import { ResearchesTableLabels } from 'types/cohorts'
+import { accessType } from 'types/scope'
+import { CellType } from 'types/table'
 
 const appConfig = getConfig()
 
@@ -41,5 +44,62 @@ describe('mappers/samples.mapSamplesToTable', () => {
     const list = [cohort({ uuid: 's1' }), cohort({ uuid: 's2', request_job_status: JobStatus.PENDING })]
     const table = mapSamplesToTable(list, appConfig, callbacks, [list[0]], 'cohort-1', true)
     expect(table.rows).toHaveLength(2)
+  })
+
+  describe('colonne sensibilité (CNIL)', () => {
+    const sensitivityCell = (table: ReturnType<typeof mapSamplesToTable>) =>
+      table.rows[0].find((cell) => cell.id === 's1-sensitivity')
+
+    it('ajoute une colonne "sensibilité" après le statut', () => {
+      const table = mapSamplesToTable([cohort()], appConfig, callbacks, [], 'cohort-1', false)
+      const labels = table.columns.map((col) => col.label)
+      expect(labels).toContain(ResearchesTableLabels.SENSITIVITY)
+      expect(labels.indexOf(ResearchesTableLabels.SENSITIVITY)).toBe(
+        labels.indexOf(ResearchesTableLabels.STATUS) + 1
+      )
+    })
+
+    it('rend une cellule sensibilité pour chaque échantillon', () => {
+      const table = mapSamplesToTable([cohort()], appConfig, callbacks, [], 'cohort-1', false)
+      expect(sensitivityCell(table)?.type).toBe(CellType.TEXT)
+    })
+
+    it('affiche "Nominatif" quand la lecture nominative est autorisée (read_patient_nomi)', () => {
+      const table = mapSamplesToTable(
+        [cohort({ rights: { read_patient_nomi: true, read_patient_pseudo: true } })],
+        appConfig,
+        callbacks,
+        [],
+        'cohort-1',
+        false
+      )
+      expect(sensitivityCell(table)?.value).toBe(accessType.NOMINAL)
+    })
+
+    it('affiche "Pseudonymisé" pour une lecture pseudonymisée, y compris avec un droit d\'export nominatif', () => {
+      const pseudoOnly = mapSamplesToTable(
+        [cohort({ rights: { read_patient_nomi: false, read_patient_pseudo: true } })],
+        appConfig,
+        callbacks,
+        [],
+        'cohort-1',
+        false
+      )
+      const exportButPseudo = mapSamplesToTable(
+        [cohort({ rights: { export_csv_xlsx_nomi: true, read_patient_nomi: false, read_patient_pseudo: true } })],
+        appConfig,
+        callbacks,
+        [],
+        'cohort-1',
+        false
+      )
+      expect(pseudoOnly.rows[0].find((cell) => cell.id === 's1-sensitivity')?.value).toBe(accessType.PSEUDO)
+      expect(exportButPseudo.rows[0].find((cell) => cell.id === 's1-sensitivity')?.value).toBe(accessType.PSEUDO)
+    })
+
+    it('reste indéterminée (valeur vide) quand les droits sont absents', () => {
+      const table = mapSamplesToTable([cohort()], appConfig, callbacks, [], 'cohort-1', false)
+      expect(sensitivityCell(table)?.value).toBe('')
+    })
   })
 })

--- a/src/__tests__/services/servicePerimeters.test.ts
+++ b/src/__tests__/services/servicePerimeters.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { AxiosResponse } from 'axios'
 import { ReadRightPerimeter } from 'types'
-import { ScopeElement, SourceType, System, Rights } from 'types/scope'
+import { ScopeElement, SourceType, System, Rights, accessType } from 'types/scope'
 import { Hierarchy } from 'types/hierarchy'
 
 // --- Mocks ---------------------------------------------------------------
@@ -75,19 +75,28 @@ beforeEach(() => {
 // --- getAccessFromRights (pure logic, params invalides) ------------------
 
 describe('servicePerimeters.getAccessFromRights', () => {
-  it('retourne "Nominatif" quand read_access vaut DATA_NOMINATIVE', () => {
+  it('retourne accessType.NOMINAL quand read_access vaut DATA_NOMINATIVE', () => {
     const rights = makeReadRight({ read_access: 'DATA_NOMINATIVE' })
-    expect(servicesPerimeters.getAccessFromRights(rights)).toBe('Nominatif')
+    expect(servicesPerimeters.getAccessFromRights(rights)).toBe(accessType.NOMINAL)
   })
 
-  it('retourne "Nominatif" quand right_read_patient_nominative est true', () => {
+  it('retourne accessType.NOMINAL quand right_read_patient_nominative est true', () => {
     const rights = makeReadRight({ right_read_patient_nominative: true })
-    expect(servicesPerimeters.getAccessFromRights(rights)).toBe('Nominatif')
+    expect(servicesPerimeters.getAccessFromRights(rights)).toBe(accessType.NOMINAL)
   })
 
-  it('retourne "Pseudonymisé" par défaut sinon', () => {
+  it('retourne accessType.PSEUDO par défaut sinon', () => {
     const rights = makeReadRight({ read_access: 'DATA_PSEUDOANONYMISED', right_read_patient_nominative: false })
-    expect(servicesPerimeters.getAccessFromRights(rights)).toBe('Pseudonymisé')
+    expect(servicesPerimeters.getAccessFromRights(rights)).toBe(accessType.PSEUDO)
+  })
+
+  it('conserve la valeur "Nominatif"/"Pseudonymisé" de l’enum (compat. sérialisation)', () => {
+    expect(servicesPerimeters.getAccessFromRights(makeReadRight({ right_read_patient_nominative: true }))).toBe(
+      'Nominatif'
+    )
+    expect(servicesPerimeters.getAccessFromRights(makeReadRight({ right_read_patient_nominative: false }))).toBe(
+      'Pseudonymisé'
+    )
   })
 })
 
@@ -103,7 +112,7 @@ describe('servicePerimeters.mapRightsToScopeElement', () => {
     expect(result.id).toBe('42')
     expect(result.system).toBe(System.ScopeTree)
     expect(result.label).toBe('H-42 - Hôpital 42')
-    expect(result.access).toBe('Nominatif')
+    expect(result.access).toBe(accessType.NOMINAL)
     expect(result.rights?.read_access).toBe('DATA_NOMINATIVE')
     expect(result.rights?.export_access).toBe('DATA_PSEUDOANONYMISED')
   })
@@ -111,7 +120,7 @@ describe('servicePerimeters.mapRightsToScopeElement', () => {
   it('mappe un droit pseudonymisé vers accès "Pseudonymisé"', () => {
     const item = makeReadRight({ right_read_patient_nominative: false })
     const result = servicesPerimeters.mapRightsToScopeElement(item)
-    expect(result.access).toBe('Pseudonymisé')
+    expect(result.access).toBe(accessType.PSEUDO)
     expect(result.rights?.read_access).toBe('DATA_PSEUDOANONYMISED')
   })
 })

--- a/src/__tests__/utilsFunction/explorationUtils.test.ts
+++ b/src/__tests__/utilsFunction/explorationUtils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { getCohortSensitivity } from 'utils/explorationUtils'
+import { accessType } from 'types/scope'
+import { GroupRights } from 'types'
+
+describe('explorationUtils.getCohortSensitivity', () => {
+  it('retourne NOMINAL dès que la lecture nominative est autorisée', () => {
+    expect(getCohortSensitivity({ read_patient_nomi: true })).toBe(accessType.NOMINAL)
+    expect(getCohortSensitivity({ read_patient_nomi: true, read_patient_pseudo: true })).toBe(accessType.NOMINAL)
+    expect(getCohortSensitivity({ read_patient_nomi: true, read_patient_pseudo: false })).toBe(accessType.NOMINAL)
+  })
+
+  it('retourne PSEUDO quand seule la lecture pseudonymisée est autorisée', () => {
+    expect(getCohortSensitivity({ read_patient_nomi: false, read_patient_pseudo: true })).toBe(accessType.PSEUDO)
+    expect(getCohortSensitivity({ read_patient_pseudo: true })).toBe(accessType.PSEUDO)
+  })
+
+  it("est basé sur la lecture, pas sur l'export : export nominatif + lecture pseudo => PSEUDO", () => {
+    expect(
+      getCohortSensitivity({ export_csv_xlsx_nomi: true, read_patient_nomi: false, read_patient_pseudo: true })
+    ).toBe(accessType.PSEUDO)
+  })
+
+  it('retourne undefined quand les droits sont inconnus ou vides', () => {
+    expect(getCohortSensitivity(undefined)).toBeUndefined()
+    expect(getCohortSensitivity({})).toBeUndefined()
+    expect(getCohortSensitivity({ read_patient_nomi: false, read_patient_pseudo: false })).toBeUndefined()
+    // un droit d'export seul ne suffit pas à qualifier la consultation
+    expect(getCohortSensitivity({ export_csv_xlsx_nomi: true } as GroupRights)).toBeUndefined()
+  })
+})

--- a/src/components/CreationCohort/ControlPanel/ControlPanel.tsx
+++ b/src/components/CreationCohort/ControlPanel/ControlPanel.tsx
@@ -65,6 +65,7 @@ import { isRequestFinished } from './utils'
 import { useCountReconciliation } from './useCountReconciliation'
 import { CriteriaType } from 'types/requestCriterias'
 import useMaintenanceIsActive from 'hooks/maintenance/useMaintenanceIsActive'
+import { accessType } from 'types/scope'
 
 const ControlPanel: React.FC<{
   canExecuteJson: boolean
@@ -124,7 +125,7 @@ const ControlPanel: React.FC<{
   const accessIsPseudonymize: boolean | null =
     selectedPopulation === null
       ? null
-      : selectedPopulation.map((population) => population?.access).some((elem) => elem && elem === 'Pseudonymisé')
+      : selectedPopulation.map((population) => population?.access).some((elem) => elem && elem === accessType.PSEUDO)
 
   let accessLabel: string
   if (accessIsPseudonymize === null) {

--- a/src/components/CreationCohort/Requeteur.tsx
+++ b/src/components/CreationCohort/Requeteur.tsx
@@ -29,6 +29,7 @@ import { setCriteriaData } from 'state/criteria'
 import { AppConfig } from 'config'
 import { initValueSets, updateCache } from 'state/valueSets'
 import { initQuestionnairesFormData } from 'state/questionnairesFormData'
+import { accessType } from 'types/scope'
 
 const Requeteur = () => {
   const {
@@ -106,7 +107,8 @@ const Requeteur = () => {
         dispatch(buildCohortCreation({ selectedPopulation: null }))
       }
 
-      const allowMaternityForms = selectedPopulation?.every((population) => population?.access === 'Nominatif')
+      const allowMaternityForms =
+        selectedPopulation?.every((population) => population?.access === accessType.NOMINAL) ?? false
       const questionnairesEnabled = config.features.questionnaires.enabled
       dispatch(
         setCriteriaData({
@@ -135,7 +137,7 @@ const Requeteur = () => {
   }, [dispatch, selectedCriteria, allowSearchIpp, selectedPopulation])
 
   useEffect(() => {
-    if (selectedPopulation?.some((perimeter) => perimeter?.access === 'Pseudonymisé') && isCriteriaNominative) {
+    if (selectedPopulation?.some((perimeter) => perimeter?.access === accessType.PSEUDO) && isCriteriaNominative) {
       cleanNominativeCriterias(selectedCriteria, criteriaGroup, dispatch)
     }
   }, [selectedPopulation, isCriteriaNominative])

--- a/src/mappers/cohorts.ts
+++ b/src/mappers/cohorts.ts
@@ -2,7 +2,13 @@ import { Cohort, JobStatus } from 'types'
 import { CohortCallbacks, ResearchesTableLabels, SubItemType } from 'types/cohorts'
 import { Order } from 'types/searchCriterias'
 import { Action, CellType, Column, Favorite, Row, SubItem, Table } from 'types/table'
-import { getExportTooltip, getGlobalEstimation, isCohortExportable, isExportDisabled } from 'utils/explorationUtils'
+import {
+  getCohortSensitivity,
+  getExportTooltip,
+  getGlobalEstimation,
+  isCohortExportable,
+  isExportDisabled
+} from 'utils/explorationUtils'
 import { formatDate } from 'utils/dates'
 import { format } from 'utils/numbers'
 import Download from 'assets/icones/download.svg?react'
@@ -21,8 +27,9 @@ const getCohortInfos = (cohort: Cohort) => {
   const globalTotal = getGlobalEstimation(cohort)
   const createdAt = formatDate(cohort.created_at)
   const samples = cohort.sample_cohorts?.length ?? 0
+  const sensitivity = getCohortSensitivity(cohort.rights) ?? ''
 
-  return { name, parentName, statusChip, total, globalTotal, createdAt, samples }
+  return { name, parentName, statusChip, total, globalTotal, createdAt, samples, sensitivity }
 }
 
 const mapCohortsToRows = (
@@ -36,7 +43,7 @@ const mapCohortsToRows = (
 ) => {
   const rows: Row[] = []
   list.forEach((cohort) => {
-    const { name, parentName, statusChip, total, globalTotal, createdAt, samples } = getCohortInfos(cohort)
+    const { name, parentName, statusChip, total, globalTotal, createdAt, samples, sensitivity } = getCohortInfos(cohort)
     const {
       onClickCreateSample,
       onClickRow,
@@ -135,6 +142,12 @@ const mapCohortsToRows = (
         type: CellType.STATUS_CHIP
       },
       {
+        id: `${cohort.uuid}-sensitivity`,
+        value: sensitivity,
+        type: CellType.TEXT,
+        sx: { width: 150 }
+      },
+      {
         id: `${cohort.uuid}-total`,
         value: total,
         type: CellType.TEXT,
@@ -194,6 +207,7 @@ const mapCohortsToColumns = (
       ? []
       : [{ label: ResearchesTableLabels.PARENT_REQUEST, code: simplified ? undefined : Order.REQUEST }]),
     { label: ResearchesTableLabels.STATUS },
+    { label: ResearchesTableLabels.SENSITIVITY },
     { label: ResearchesTableLabels.PATIENT_TOTAL, code: simplified ? undefined : Order.RESULT_SIZE },
     {
       label: ResearchesTableLabels.APHP_TOTAL,

--- a/src/mappers/samples.ts
+++ b/src/mappers/samples.ts
@@ -3,7 +3,13 @@ import { Cohort } from 'types'
 import { CohortCallbacks, ResearchesTableLabels } from 'types/cohorts'
 import { Order } from 'types/searchCriterias'
 import { Action, CellType, Column, Favorite, Row, Table } from 'types/table'
-import { getExportTooltip, getGlobalEstimation, isCohortExportable, isExportDisabled } from 'utils/explorationUtils'
+import {
+  getCohortSensitivity,
+  getExportTooltip,
+  getGlobalEstimation,
+  isCohortExportable,
+  isExportDisabled
+} from 'utils/explorationUtils'
 import { formatDate } from 'utils/dates'
 import { format, formatPercentage } from 'utils/numbers'
 import Download from 'assets/icones/download.svg?react'
@@ -21,6 +27,7 @@ const getSamplesInfos = (cohort: Cohort) => {
   const createdAt = formatDate(cohort.created_at)
   const samples = cohort.sample_cohorts?.length ?? 0
   const samplingRatio = formatPercentage(cohort.sampling_ratio)
+  const sensitivity = getCohortSensitivity(cohort.rights) ?? ''
   return {
     name,
     parentName,
@@ -29,7 +36,8 @@ const getSamplesInfos = (cohort: Cohort) => {
     globalTotal,
     createdAt,
     samples,
-    samplingRatio
+    samplingRatio,
+    sensitivity
   }
 }
 
@@ -43,7 +51,7 @@ const mapSamplesToRows = (
 ) => {
   const rows: Row[] = []
   list.forEach((cohort) => {
-    const { name, parentName, statusChip, total, createdAt, samplingRatio } = getSamplesInfos(cohort)
+    const { name, parentName, statusChip, total, createdAt, samplingRatio, sensitivity } = getSamplesInfos(cohort)
     const { onClickRow, onClickFav, onClickExport, onClickEdit, onSelectCohort, onClickCohortVersion } = callbacks
     const actions = [
       {
@@ -103,6 +111,12 @@ const mapSamplesToRows = (
         type: CellType.STATUS_CHIP
       },
       {
+        id: `${cohort.uuid}-sensitivity`,
+        value: sensitivity,
+        type: CellType.TEXT,
+        sx: { width: 150 }
+      },
+      {
         id: `${cohort.uuid}-total`,
         value: total,
         type: CellType.TEXT,
@@ -149,6 +163,7 @@ const mapSamplesToColumns = (
     { label: '' },
     ...(cohortId ? [] : [{ label: ResearchesTableLabels.PARENT_COHORT, code: Order.REQUEST }]),
     { label: ResearchesTableLabels.STATUS },
+    { label: ResearchesTableLabels.SENSITIVITY },
     { label: ResearchesTableLabels.PATIENT_TOTAL, code: Order.RESULT_SIZE },
     { label: ResearchesTableLabels.TOTAL_PERCENTAGE },
     { label: ResearchesTableLabels.CREATED_AT, code: Order.CREATED_AT }

--- a/src/services/aphp/servicePerimeters.ts
+++ b/src/services/aphp/servicePerimeters.ts
@@ -23,6 +23,7 @@ import { FetchScopeOptions, Rights, ScopeElement, SourceType, System } from 'typ
 import { scopeLevelsToRequestParam } from 'utils/perimeters'
 import { mapParamsToNetworkParams } from 'utils/url'
 import { Hierarchy } from 'types/hierarchy'
+import { accessType } from 'types/scope'
 import { getExtension } from 'utils/fhir'
 
 export interface IServicePerimeters {
@@ -97,7 +98,7 @@ export interface IServicePerimeters {
    * à travers un ScopePage on retourne 'Nominatif' ou 'Pseudonymisé' selon les droits d'accès
    * @param perimeterItem
    */
-  getAccessFromRights: (item: ReadRightPerimeter) => 'Nominatif' | 'Pseudonymisé'
+  getAccessFromRights: (item: ReadRightPerimeter) => accessType
 }
 
 const servicesPerimeters: IServicePerimeters = {
@@ -384,8 +385,8 @@ const servicesPerimeters: IServicePerimeters = {
 
   getAccessFromRights: (rights: ReadRightPerimeter) => {
     return rights.read_access === 'DATA_NOMINATIVE' || rights.right_read_patient_nominative === true
-      ? 'Nominatif'
-      : 'Pseudonymisé'
+      ? accessType.NOMINAL
+      : accessType.PSEUDO
   }
 }
 

--- a/src/types/cohorts.ts
+++ b/src/types/cohorts.ts
@@ -19,6 +19,7 @@ export enum ResearchesTableLabels {
   PARENT_COHORT = 'cohorte parent',
   TOTAL_PERCENTAGE = 'pourcentage du total',
   STATUS = 'statut',
+  SENSITIVITY = 'sensibilité',
   PATIENT_TOTAL = 'nb de patients',
   APHP_TOTAL = 'estimation du nb de patients ap-hp',
   CREATED_AT = 'date de création',

--- a/src/types/scope.ts
+++ b/src/types/scope.ts
@@ -45,5 +45,10 @@ export type ScopeElement = {
   cohort_size: string
   full_path: string
   rights?: ReadRightPerimeter
-  access?: 'Nominatif' | 'Pseudonymisé'
+  access?: accessType
+}
+
+export enum accessType {
+  NOMINAL = 'Nominatif',
+  PSEUDO = 'Pseudonymisé'
 }

--- a/src/utils/explorationUtils.ts
+++ b/src/utils/explorationUtils.ts
@@ -1,4 +1,5 @@
-import { Cohort, JobStatus, ProjectType, QuerySnapshotInfo, RequestType } from 'types'
+import { Cohort, GroupRights, JobStatus, ProjectType, QuerySnapshotInfo, RequestType } from 'types'
+import { accessType } from 'types/scope'
 import { CohortsType, ExplorationsSearchParams } from 'types/cohorts'
 import {
   CohortsFilters,
@@ -105,6 +106,20 @@ export const redirectOnParentCohortDeletion = (parentRequestId?: string, parentF
 
 export const isCohortExportable = (cohort: Cohort, appConfig: AppConfig) => {
   return appConfig.features.export.enabled ? !!cohort?.rights?.export_csv_xlsx_nomi : false
+}
+
+/**
+ * Niveau de sensibilité des données de la cohorte pour l'utilisateur courant, au sens CNIL :
+ * distingue une consultation en clair (nominatif) d'une consultation pseudonymisée. Cette
+ * distinction conditionne les obligations de traçabilité et de sécurité de l'utilisateur, elle
+ * repose donc sur les droits de LECTURE (`read_patient_nomi` / `read_patient_pseudo`) et non sur
+ * le droit d'export (`export_csv_xlsx_nomi`).
+ * Retourne `undefined` quand les droits sont inconnus ou absents : on préfère n'afficher aucune
+ * mention plutôt qu'une mention « Pseudonymisé » qui sous-estimerait les obligations.
+ */
+export const getCohortSensitivity = (rights?: GroupRights): accessType | undefined => {
+  if (!rights || (!rights.read_patient_nomi && !rights.read_patient_pseudo)) return undefined
+  return rights.read_patient_nomi ? accessType.NOMINAL : accessType.PSEUDO
 }
 
 export const isExportDisabled = (cohort: Cohort, maintenanceIsActive: boolean, isExportable: boolean) => {


### PR DESCRIPTION
## Objectif
Adding `sensibilité` column on `Mes cohortes`, `Mes dernières cohortes créées`, `Mes cohortes favorites`, and `Mes échantillons`
More details: https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3432

## Changements réalisés
- Nouvel énuméré accessType
    - src/types/scope.ts : ajout de l'énumération accessType { NOMINAL = 'Nominatif', PSEUDO = 'Pseudonymisé' }. Le
  champ ScopeElement.access passe de l'union de chaînes 'Nominatif' | 'Pseudonymisé' à accessType.
- Nouvelle colonne « sensibilité » dans les tables
- Alignement des consommateurs sur l'énumération
    - src/services/aphp/servicePerimeters.ts
    - src/components/CreationCohort/Requeteur.tsx
    - src/components/CreationCohort/ControlPanel/ControlPanel.tsx
- Tests unitaires

<img width="1302" height="446" alt="Screenshot From 2026-09-09 11-19-17" src="https://github.com/user-attachments/assets/bbd70874-036b-43c7-af07-0b100e3a3144" />
<img width="1297" height="200" alt="Screenshot From 2026-09-09 11-19-26" src="https://github.com/user-attachments/assets/f1de2433-eef5-461f-8daa-3fd0bd7153a9" />
<img width="1296" height="225" alt="Screenshot From 2026-09-09 11-19-38" src="https://github.com/user-attachments/assets/1859391e-9be7-4a57-abc3-393486589b77" />


## Impacts
Front uniquement

## Tests réalisés
- npx eslint src/mappers/
- npx vitest run src/__tests__/services/servicePerimeters.test.ts
- npx vitest run src/__tests__/utilsFunction/explorationUtils.test.ts
- npx tsc --noEmit

## Risques
Ce qui peut casser, points de vigilance.
