### PR TITLE
fix: champ unité exécutrice fontionne comme les autre champs du requê…

### DIFF
--- a/src/__tests__/components/ui/Inputs/ExecutiveUnits/index.test.tsx
+++ b/src/__tests__/components/ui/Inputs/ExecutiveUnits/index.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SourceType } from 'types/scope'
+
+const getPerimeters = vi.fn().mockResolvedValue({ results: [], count: 0 })
+vi.mock('services/aphp/servicePerimeters', () => ({
+  default: { getPerimeters: (...args: unknown[]) => getPerimeters(...args) }
+}))
+vi.mock('components/ScopeTree', () => ({ default: () => <div data-testid="scope-tree" /> }))
+
+import ExecutiveUnits from 'components/ui/Inputs/ExecutiveUnits'
+
+const PLACEHOLDER = 'Sélectionner une unité exécutrice'
+
+const renderField = (props: { disabled?: boolean } = {}) =>
+  render(<ExecutiveUnits value={[]} sourceType={SourceType.SUPPORTED} onChange={vi.fn()} disabled={props.disabled} />)
+
+// The selection panel only mounts its content (incl. the "Annuler" button) while open.
+const panelOpen = () => screen.queryByRole('button', { name: /annuler/i }) !== null
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('components/ui/Inputs/ExecutiveUnits', () => {
+  it("ouvre le panneau au clic n'importe où sur le champ, pas seulement sur la loupe", async () => {
+    renderField()
+    await screen.findByTestId('SearchOutlinedIcon') // wait for the initial getPerimeters() effect
+
+    expect(panelOpen()).toBe(false)
+
+    await userEvent.click(screen.getByText(PLACEHOLDER))
+
+    expect(await screen.findByRole('button', { name: /annuler/i })).toBeInTheDocument()
+  })
+
+  it('ne réagit pas au clic quand le champ est désactivé', async () => {
+    renderField({ disabled: true })
+
+    await userEvent.click(screen.getByText(PLACEHOLDER))
+
+    expect(panelOpen()).toBe(false)
+    expect(getPerimeters).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/ui/Inputs/ExecutiveUnits/index.tsx
+++ b/src/components/ui/Inputs/ExecutiveUnits/index.tsx
@@ -36,6 +36,12 @@ const ExecutiveUnits = ({ value, sourceType, disabled = false, onChange, label }
     onChange(newSelectedPopulation)
   }
 
+  const handleOpen = () => {
+    if (disabled) return
+    setOpen(true)
+    setIsExtended(false)
+  }
+
   useEffect(() => {
     const handleFetchPopulation = async () => {
       const response = await servicesPerimeters.getPerimeters({ sourceType: SourceType.APHP })
@@ -71,9 +77,17 @@ const ExecutiveUnits = ({ value, sourceType, disabled = false, onChange, label }
           padding: '9px 3px 9px 12px'
         }}
       >
-        <Grid container size={{ xs: 10 }} sx={{ alignItems: 'center' }}>
-          {!value.length && <FormLabel component="legend">Sélectionner une unité exécutrice</FormLabel>}
+        <Grid
+          container
+          size={{ xs: 10 }}
+          sx={{ alignItems: 'center' }}
+          role="button"
+          tabIndex={0}
+          style={{ cursor: disabled ? 'default' : 'pointer' }}
+          onClick={handleOpen}
+        >
           <CodesWithSystems disabled={disabled} codes={value} isExtended={isExtended} onDelete={handleDelete} />
+          {!value.length && <FormLabel component="legend">Sélectionner une unité exécutrice</FormLabel>}
         </Grid>
         <Grid size={{ xs: 2 }} container sx={{ justifyContent: 'flex-end' }}>
           {value.length > 0 && isExtended && (
@@ -86,15 +100,7 @@ const ExecutiveUnits = ({ value, sourceType, disabled = false, onChange, label }
               <MoreHorizIcon />
             </IconButton>
           )}
-          <IconButton
-            sx={{ color: '#5BC5F2' }}
-            size="small"
-            onClick={() => {
-              setOpen(true)
-              setIsExtended(false)
-            }}
-            disabled={disabled}
-          >
+          <IconButton sx={{ color: '#5BC5F2' }} size="small" onClick={handleOpen} disabled={disabled}>
             {loading === LoadingStatus.FETCHING && <CircularProgress size={24} />}
             {loading === LoadingStatus.SUCCESS && <SearchOutlined data-testid="SearchOutlinedIcon" />}
           </IconButton>

--- a/src/components/ui/Inputs/ExecutiveUnits/index.tsx
+++ b/src/components/ui/Inputs/ExecutiveUnits/index.tsx
@@ -81,8 +81,6 @@ const ExecutiveUnits = ({ value, sourceType, disabled = false, onChange, label }
           container
           size={{ xs: 10 }}
           sx={{ alignItems: 'center' }}
-          role="button"
-          tabIndex={0}
           style={{ cursor: disabled ? 'default' : 'pointer' }}
           onClick={handleOpen}
         >


### PR DESCRIPTION
## Objectif
If user clicks the unité exécutrice field, it happened nothing unless user click the search icon. Meanwhile, other fields such as biology opened the popup whether user clicks the field or search icon.
Make unité exécutrice field works like others field.

## Changements réalisés
Wrap ExecutiveUnits with Grid

## Impacts
Front

## Tests réalisés
None

## Risques
None
