### PR TITLE
chore(deps): retire l'épinglage de postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12191,9 +12191,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -12211,9 +12211,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
   },
   "overrides": {
     "nth-check": "2.1.1",
-    "tough-cookie": "4.1.3",
-    "postcss": "8.4.31"
+    "tough-cookie": "4.1.3"
   },
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
## Objectif
L'override `postcss` fige la dépendance en 8.4.31 et laisse quatre avis de sécurité ouverts, dont deux hauts, sans que Dependabot puisse proposer quoi que ce soit. 

Related to #1351 

## Changements réalisés
Suppression de l'entrée `postcss` du bloc `overrides`, postcss passe en 8.5.28. L'entrée du lock est éditée à la main pour ne pas régénérer le fichier hors Linux.

## Impacts
Front, chaîne de build uniquement. postcss est en `dev` dans le lock, il n'entre pas dans le bundle.

## Tests réalisés
`npm ci` à blanc validé en local, la CI joue lint, typecheck et tests sur la branche.

## Risques
Saut de mineure sur postcss après deux ans de gel. Vite déclare `^8.5.6`, l'override le tenait en dessous de sa propre plage.
