### PR TITLE
fix(export): retire la mention de patient__identifier sur la table Patient

### DIFF
--- a/src/__tests__/components/ExportTable.test.tsx
+++ b/src/__tests__/components/ExportTable.test.tsx
@@ -100,15 +100,16 @@ describe('ExportTable', () => {
     expect(await screen.findByText('Patient')).toBeInTheDocument()
   })
 
-  it('signale la sous-table patient__identifier sur la table Patient', async () => {
+  it('ne mentionne pas patient__identifier sur la table Patient', async () => {
     renderTable({ exportTable: { ...tableInfo, name: 'Patient' } })
-    expect(await screen.findByText(/patient__identifier sera également exportée/)).toBeInTheDocument()
+    await screen.findAllByText('Patient')
+    expect(screen.queryByText(/patient__identifier/)).not.toBeInTheDocument()
   })
 
-  it('masque la mention de patient__identifier en export regroupé', async () => {
+  it('ne mentionne pas patient__identifier en export regroupé', async () => {
     renderTable({ exportTable: { ...tableInfo, name: 'Patient' }, oneFile: true })
     await screen.findAllByText('Patient')
-    expect(screen.queryByText(/patient__identifier sera également exportée/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/patient__identifier/)).not.toBeInTheDocument()
   })
 
 })

--- a/src/pages/ExportRequest/components/ExportTable/index.tsx
+++ b/src/pages/ExportRequest/components/ExportTable/index.tsx
@@ -294,11 +294,6 @@ const ExportTable: React.FC<ExportTableProps> = ({
               {']'}
             </Typography>
           </div>
-          {exportTable.name === 'Patient' && !oneFile && (
-            <Typography variant="caption" fontStyle="italic" color="#888" sx={{ width: '100%', mt: '4px' }}>
-              La sous-table patient__identifier sera également exportée avec la table Patient.
-            </Typography>
-          )}
         </Grid>
 
         <Grid container size={4}>


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3515

## Changements réalisés
Suppression du libellé signalant l'export de la sous-table `patient__identifier` sur le bloc `Patient` de l'écran d'export.

## Impacts
Front.

## Tests réalisés
Tests unitaires mis à jour.

## Risques
Le front continue d'ajouter `patient__identifier` à la requête d'export sur cette branche, seul l'affichage change.
