### PR TITLE
fix(pmsi): évite l'erreur HAPI-0389 sur la fiche patient

### DIFF
--- a/src/__tests__/services/servicePmsi.test.ts
+++ b/src/__tests__/services/servicePmsi.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { Condition, Procedure } from 'fhir/r4'
+import { updateConfig } from 'config'
+import { Direction, Order, PMSIFilters } from 'types/searchCriterias'
+import { FetchParams, Patient as PatientType, PMSI_INCLUDE_PAGE_SIZE } from 'types/exploration'
+
+// Same low-level mocking approach as __tests__/services/callApi.test.ts: mock
+// apiFhir.fhirSearch directly so we can assert on the *actual wire-level* request
+// options (`_count`, `_offset`, `_include`, ...), independent of any refactor in
+// the layers in between.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fhirSearch = vi.fn((..._args: any[]) => Promise.resolve({ data: { resourceType: 'Bundle', total: 0 } }))
+
+vi.mock('../../services/apiFhir', () => ({
+  default: { get: vi.fn(async () => ({ data: {} })) },
+  fhirSearch: (...args: unknown[]) => fhirSearch(...args)
+}))
+
+vi.mock('config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('config')>()
+  return { ...actual }
+})
+
+import { fetchConditionList, fetchProcedureList, fetchLastPmsi } from 'services/aphp/servicePmsi'
+
+const ORBIS_STATUS_URL = 'http://test.aphp.fr/fhir/StructureDefinition/orbis-status'
+
+const callsFor = (resource: string) => fhirSearch.mock.calls.filter((call) => call[0] === resource)
+const optionsOf = (call: unknown[]) => (call[1] as string[]).join('&')
+
+beforeAll(() => {
+  updateConfig({ features: { condition: { extensions: { orbisStatus: ORBIS_STATUS_URL } } } })
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+const emptyFilters: PMSIFilters = {
+  executiveUnits: [],
+  encounterStatus: [],
+  code: [],
+  durationRange: [null, null]
+}
+
+const baseFetchParams: FetchParams = {
+  size: 20,
+  page: 0,
+  searchInput: '',
+  orderBy: { orderBy: Order.DATE, orderDirection: Direction.DESC },
+  includeFacets: false
+}
+
+const makePatient = (id: string): PatientType =>
+  ({
+    id,
+    deidentified: false,
+    infos: { id, hospits: [] }
+  }) as unknown as PatientType
+
+const makeCondition = (id: string, isDp: boolean): Condition => ({
+  resourceType: 'Condition',
+  id,
+  subject: { reference: 'Patient/p1' },
+  extension: isDp ? [{ url: ORBIS_STATUS_URL, valueString: 'DP' }] : []
+})
+
+const makeProcedure = (id: string): Procedure => ({
+  resourceType: 'Procedure',
+  id,
+  status: 'completed',
+  subject: { reference: 'Patient/p1' }
+})
+
+describe('fetchLastPmsi (Part 1 — must not request _include)', () => {
+  it('never sends _include on any Condition or Procedure request, and still returns the fetched resources', async () => {
+    const conditions = [makeCondition('c1', true), makeCondition('c2', false)]
+    const procedures = [makeProcedure('p1'), makeProcedure('p2')]
+
+    fhirSearch.mockImplementation(async (resource: string, options: string[]) => {
+      const isCountOnly = options.includes('_count=0')
+      if (resource === 'Condition') {
+        return {
+          data: {
+            resourceType: 'Bundle',
+            total: conditions.length,
+            entry: isCountOnly ? undefined : conditions.map((resource) => ({ resource }))
+          }
+        }
+      }
+      if (resource === 'Procedure') {
+        return {
+          data: {
+            resourceType: 'Bundle',
+            total: procedures.length,
+            entry: isCountOnly ? undefined : procedures.map((resource) => ({ resource }))
+          }
+        }
+      }
+      return { data: { resourceType: 'Bundle', total: 0, entry: [] } }
+    })
+
+    const patient = makePatient('p1')
+    const result = await fetchLastPmsi({ patient })
+
+    const conditionCalls = callsFor('Condition')
+    const procedureCalls = callsFor('Procedure')
+    expect(conditionCalls.length).toBeGreaterThan(0)
+    expect(procedureCalls.length).toBeGreaterThan(0)
+
+    for (const call of [...conditionCalls, ...procedureCalls]) {
+      expect(optionsOf(call)).not.toMatch(/_include=/)
+    }
+
+    // The produced PMSI result is unchanged by dropping `_include`: the main
+    // resources still flow through to lastProcedure/mainDiagnosis/procedures/diagnostics.
+    expect(result?.procedures?.map((p) => p.id)).toEqual(['p1', 'p2'])
+    expect(result?.diagnostics?.map((c) => c.id)).toEqual(['c1', 'c2'])
+    expect(result?.lastProcedure?.id).toBe('p1')
+    expect(result?.mainDiagnosis?.map((c) => c.id)).toEqual(['c1'])
+  })
+})
+
+describe('fetchConditionList / fetchProcedureList (Part 1 — default behavior for other callers)', () => {
+  it('still requests _include by default (e.g. ExplorationBoard / cohort-level callers)', async () => {
+    fhirSearch.mockResolvedValue({ data: { resourceType: 'Bundle', total: 0, entry: [] } } as never)
+
+    await fetchConditionList(baseFetchParams, { filters: emptyFilters }, null, false, [])
+    const conditionOptions = optionsOf(callsFor('Condition')[0])
+    expect(conditionOptions).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(conditionOptions).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+
+    await fetchProcedureList(baseFetchParams, { filters: emptyFilters }, null, false, [])
+    const procedureOptions = optionsOf(callsFor('Procedure')[0])
+    expect(procedureOptions).toContain(`_include=${encodeURIComponent('Encounter:encounter')}`)
+    expect(procedureOptions).toContain(`_include=${encodeURIComponent('Patient:subject')}`)
+  })
+
+  it('omits _include when includeRelatedResources is explicitly false (fetchLastPmsi behavior)', async () => {
+    fhirSearch.mockResolvedValue({ data: { resourceType: 'Bundle', total: 0, entry: [] } } as never)
+
+    await fetchConditionList(baseFetchParams, { filters: emptyFilters }, null, false, [], undefined, false)
+    expect(optionsOf(callsFor('Condition')[0])).not.toMatch(/_include=/)
+  })
+})
+
+describe('fetchProcedureList / fetchConditionList (Part 2 — bounded pagination while _include is required)', () => {
+  const patient = makePatient('p1')
+
+  it('paginates in PMSI_INCLUDE_PAGE_SIZE chunks, still requests _include on every page, and combines all pages without truncation', async () => {
+    const total = PMSI_INCLUDE_PAGE_SIZE * 2 + 3
+    const allProcedures = Array.from({ length: total }, (_, i) => makeProcedure(`p${i}`))
+
+    fhirSearch.mockImplementation(async (resource: string, options: string[]) => {
+      if (resource !== 'Procedure') return { data: { resourceType: 'Bundle', total: 0, entry: [] } }
+      const countOpt = options.find((o) => o.startsWith('_count='))
+      const offsetOpt = options.find((o) => o.startsWith('_offset='))
+      const count = Number(countOpt?.split('=')[1] ?? 0)
+      const offset = Number(offsetOpt?.split('=')[1] ?? 0)
+      return {
+        data: {
+          resourceType: 'Bundle',
+          total,
+          entry: allProcedures.slice(offset, offset + count).map((resource) => ({ resource }))
+        }
+      }
+    })
+
+    const result = await fetchProcedureList(
+      { ...baseFetchParams, size: total },
+      { filters: emptyFilters },
+      patient,
+      false,
+      []
+    )
+
+    const procedureCalls = callsFor('Procedure')
+    expect(procedureCalls).toHaveLength(3)
+
+    const offsets = procedureCalls.map((call) => {
+      const opt = (call[1] as string[]).find((o) => o.startsWith('_offset='))
+      return Number(opt?.split('=')[1] ?? 0)
+    })
+    expect(offsets).toEqual([0, PMSI_INCLUDE_PAGE_SIZE, PMSI_INCLUDE_PAGE_SIZE * 2])
+
+    // Every page must still carry `_include`: the shared pagination helper does not
+    // change this caller's need for included Encounter/Patient resources.
+    for (const call of procedureCalls) {
+      expect(optionsOf(call)).toMatch(/_include=/)
+    }
+
+    // No silent truncation: all `total` resources, including the one only present
+    // on the final page, come back in the combined, order-preserved result.
+    expect(result.list.map((p) => p.id)).toEqual(allProcedures.map((p) => p.id))
+  })
+})

--- a/src/__tests__/utilsFunction/exploration.test.ts
+++ b/src/__tests__/utilsFunction/exploration.test.ts
@@ -20,9 +20,10 @@ vi.mock('utils/encounter', () => ({
   linkElementWithEncounter: vi.fn()
 }))
 
-import { fetcherWithParams } from 'utils/exploration'
+import { fetcherWithParams, fetchInPages } from 'utils/exploration'
 import { getResourceInfos, getResourceInfosFromBundle } from 'utils/fillElement'
 import { linkElementWithEncounter } from 'utils/encounter'
+import { PMSI_INCLUDE_PAGE_SIZE } from 'types/exploration'
 
 const mockGetResourceInfos = vi.mocked(getResourceInfos)
 const mockGetResourceInfosFromBundle = vi.mocked(getResourceInfosFromBundle)
@@ -185,5 +186,98 @@ describe('fetcherWithParams _include handling', () => {
     expect(mockGetResourceInfosFromBundle).not.toHaveBeenCalled()
     expect(mockLinkElementWithEncounter).not.toHaveBeenCalled()
     expect(result.list).toEqual([patient])
+  })
+})
+
+describe('fetchInPages', () => {
+  const makePagedBundle = (ids: string[], total: number) => makeBundle(ids.map(makeCondition), total)
+
+  it('issues a single request when the requested size already fits in one page', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(makePagedBundle(['c0'], 1))
+
+    const result = await fetchInPages(fetchPage, PMSI_INCLUDE_PAGE_SIZE, 0)
+
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+    expect(fetchPage).toHaveBeenCalledWith(PMSI_INCLUDE_PAGE_SIZE, 0)
+    expect((result.data as { total: number }).total).toBe(1)
+  })
+
+  it('paginates in bounded pages, preserving order, when size exceeds one page', async () => {
+    const total = PMSI_INCLUDE_PAGE_SIZE * 2 + 5
+    const allIds = Array.from({ length: total }, (_, i) => `c${i}`)
+
+    const fetchPage = vi.fn(async (size: number, offset: number) =>
+      makePagedBundle(allIds.slice(offset, offset + size), total)
+    )
+
+    const result = await fetchInPages(fetchPage, total, 0)
+
+    expect(fetchPage).toHaveBeenCalledTimes(3)
+    expect(fetchPage).toHaveBeenNthCalledWith(1, PMSI_INCLUDE_PAGE_SIZE, 0)
+    expect(fetchPage).toHaveBeenNthCalledWith(2, PMSI_INCLUDE_PAGE_SIZE, PMSI_INCLUDE_PAGE_SIZE)
+    expect(fetchPage).toHaveBeenNthCalledWith(3, 5, PMSI_INCLUDE_PAGE_SIZE * 2)
+
+    const entryIds = (result.data as { entry: { resource: { id: string } }[] }).entry.map((e) => e.resource.id)
+    expect(entryIds).toEqual(allIds)
+  })
+
+  it('does not silently truncate a resource that only exists on the final page', async () => {
+    const total = PMSI_INCLUDE_PAGE_SIZE + 3
+    const allIds = Array.from({ length: total }, (_, i) => `c${i}`)
+    const lastPageOnlyId = allIds[allIds.length - 1]
+
+    const fetchPage = vi.fn(async (size: number, offset: number) =>
+      makePagedBundle(allIds.slice(offset, offset + size), total)
+    )
+
+    const result = await fetchInPages(fetchPage, total, 0)
+
+    const entryIds = (result.data as { entry: { resource: { id: string } }[] }).entry.map((e) => e.resource.id)
+    expect(entryIds).toContain(lastPageOnlyId)
+    expect(entryIds).toHaveLength(total)
+  })
+
+  it('stops once the reported total is reached, even if smaller than the requested size', async () => {
+    const realTotal = PMSI_INCLUDE_PAGE_SIZE + 5
+    const requestedSize = PMSI_INCLUDE_PAGE_SIZE * 3
+    const allIds = Array.from({ length: realTotal }, (_, i) => `c${i}`)
+
+    const fetchPage = vi.fn(async (size: number, offset: number) =>
+      makePagedBundle(allIds.slice(offset, offset + size), realTotal)
+    )
+
+    const result = await fetchInPages(fetchPage, requestedSize, 0)
+
+    // Only the two pages that actually contain data should be requested,
+    // never a third page beyond the server-reported total.
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+    const entryIds = (result.data as { entry: { resource: { id: string } }[] }).entry.map((e) => e.resource.id)
+    expect(entryIds).toEqual(allIds)
+  })
+
+  it('preserves the upstream sort order across combined pages without client-side reordering', async () => {
+    // Entries are handed back in whatever order fetchPage returns them (i.e. the
+    // server's `_sort`); fetchInPages must not reorder them itself.
+    const total = PMSI_INCLUDE_PAGE_SIZE + 2
+    const descendingIds = Array.from({ length: total }, (_, i) => `c${total - i}`)
+
+    const fetchPage = vi.fn(async (size: number, offset: number) =>
+      makePagedBundle(descendingIds.slice(offset, offset + size), total)
+    )
+
+    const result = await fetchInPages(fetchPage, total, 0)
+
+    const entryIds = (result.data as { entry: { resource: { id: string } }[] }).entry.map((e) => e.resource.id)
+    expect(entryIds).toEqual(descendingIds)
+  })
+
+  it('propagates a non-Bundle response (e.g. OperationOutcome) without retrying further pages', async () => {
+    const operationOutcome = { data: { resourceType: 'OperationOutcome', issue: [] } } as never
+    const fetchPage = vi.fn().mockResolvedValueOnce(operationOutcome)
+
+    const result = await fetchInPages(fetchPage, PMSI_INCLUDE_PAGE_SIZE * 2 + 1, 0)
+
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+    expect(result).toBe(operationOutcome)
   })
 })

--- a/src/services/aphp/servicePmsi.ts
+++ b/src/services/aphp/servicePmsi.ts
@@ -1,7 +1,7 @@
 import { Claim, Condition, Procedure } from 'fhir/r4'
 import { ExplorationResults, FetchOptions, FetchParams, Patient } from 'types/exploration'
 import { Direction, Order, PMSIFilters } from 'types/searchCriterias'
-import { fetcherWithParams, getCommonParamsAll, getCommonParamsList } from 'utils/exploration'
+import { fetcherWithParams, fetchInPages, getCommonParamsAll, getCommonParamsList } from 'utils/exploration'
 import { fetchClaim, fetchCondition, fetchProcedure } from './callApi'
 import { getCategory, getExtensionStringValue } from 'utils/fhir'
 import { getConfig } from 'config'
@@ -18,13 +18,22 @@ const getPMSIFilters = (
   ...getCommonParamsList(fetchParams, groupId)
 })
 
+/**
+ * @param includeRelatedResources Set to `false` to skip `_include` entirely instead
+ * of paginating around HAPI-0389 (see `fetchInPages`). Only safe for callers that
+ * don't read the included Patient/Encounter resources from the bundle — e.g.
+ * `fetchLastPmsi`, which links encounters from `patient.infos.hospits` instead.
+ * Callers that do read them (e.g. `ExplorationBoard`'s cohort-level tabs, via
+ * `getResourceInfosFromBundle`) must keep the `true` default. Defaults to `true`.
+ */
 export const fetchConditionList = (
   fetchParams: FetchParams,
   { filters }: FetchOptions<PMSIFilters>,
   patient: Patient | null,
   deidentified: boolean,
   groupId: string[],
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  includeRelatedResources = true
 ): Promise<ExplorationResults<Condition>> => {
   const { diagnosticTypes, source, code, durationRange } = filters
   const params = {
@@ -35,7 +44,9 @@ export const fetchConditionList = (
     'max-recorded-date': durationRange?.[1] ?? '',
     uniqueFacet: ['subject'],
     subject: patient?.infos?.id,
-    _include: ['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[],
+    _include: includeRelatedResources
+      ? (['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[])
+      : undefined,
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.CODE : Order.ONSET_DATE,
     signal
@@ -46,20 +57,32 @@ export const fetchConditionList = (
     ...getCommonParamsAll(groupId),
     signal
   }
-  return fetcherWithParams(
-    () => fetchCondition(params),
-    () => fetchCondition(paramsFetchAll),
-    { ...fetchParams, filters, deidentified, patient, groupId }
-  )
+  const fetchList = includeRelatedResources
+    ? () =>
+        fetchInPages<Condition>(
+          (size, offset) => fetchCondition({ ...params, size, offset }),
+          params.size,
+          params.offset
+        )
+    : () => fetchCondition(params)
+  return fetcherWithParams(fetchList, () => fetchCondition(paramsFetchAll), {
+    ...fetchParams,
+    filters,
+    deidentified,
+    patient,
+    groupId
+  })
 }
 
+/** @param includeRelatedResources See `fetchConditionList`'s doc — same rationale. */
 export const fetchProcedureList = (
   fetchParams: FetchParams,
   { filters }: FetchOptions<PMSIFilters>,
   patient: Patient | null,
   deidentified: boolean,
   groupId: string[],
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  includeRelatedResources = true
 ): Promise<ExplorationResults<Procedure>> => {
   const { source, code, durationRange } = filters
   const params = {
@@ -69,7 +92,9 @@ export const fetchProcedureList = (
     maxDate: durationRange?.[1] ?? '',
     uniqueFacet: ['subject'],
     subject: patient?.id,
-    _include: ['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[],
+    _include: includeRelatedResources
+      ? (['Encounter:encounter', 'Patient:subject'] satisfies ('Encounter:encounter' | 'Patient:subject')[])
+      : undefined,
     ...getPMSIFilters(filters, fetchParams, groupId),
     _sort: fetchParams.orderBy.orderBy === Order.CODE ? Order.CODE : Order.DATE,
     signal
@@ -80,11 +105,21 @@ export const fetchProcedureList = (
     ...getCommonParamsAll(groupId),
     signal
   }
-  return fetcherWithParams(
-    () => fetchProcedure(params),
-    () => fetchProcedure(paramsFetchAll),
-    { ...fetchParams, filters, deidentified, patient, groupId }
-  )
+  const fetchList = includeRelatedResources
+    ? () =>
+        fetchInPages<Procedure>(
+          (size, offset) => fetchProcedure({ ...params, size, offset }),
+          params.size,
+          params.offset
+        )
+    : () => fetchProcedure(params)
+  return fetcherWithParams(fetchList, () => fetchProcedure(paramsFetchAll), {
+    ...fetchParams,
+    filters,
+    deidentified,
+    patient,
+    groupId
+  })
 }
 
 export const fetchClaimList = (
@@ -140,19 +175,38 @@ export const fetchLastPmsi = async ({ patient, groupId }: { patient: Patient; gr
       durationRange: [null, null]
     }
     const groupIds = groupId ? [groupId] : []
+    const includeRelatedResources = false // see fetchConditionList's doc
     const pmsiTotal = await Promise.all([
-      fetchConditionList(fetchParams, { filters }, patient, deidentified, groupIds),
-      fetchProcedureList(fetchParams, { filters }, patient, deidentified, groupIds)
+      fetchConditionList(fetchParams, { filters }, patient, deidentified, groupIds, undefined, includeRelatedResources),
+      fetchProcedureList(fetchParams, { filters }, patient, deidentified, groupIds, undefined, includeRelatedResources)
     ])
     const diagSize = pmsiTotal[0].totalAllResults
     const procSize = pmsiTotal[1].totalAllResults
 
+    // `_count` is set to the full diagSize/procSize below — exactly the combination
+    // that triggers HAPI-0389 if `_include` is left on, hence includeRelatedResources: false.
     const fetchPatientResponse = await Promise.all([
       diagSize
-        ? fetchConditionList({ ...fetchParams, size: diagSize }, { filters }, patient, deidentified, groupIds)
+        ? fetchConditionList(
+            { ...fetchParams, size: diagSize },
+            { filters },
+            patient,
+            deidentified,
+            groupIds,
+            undefined,
+            includeRelatedResources
+          )
         : { list: [] },
       procSize
-        ? fetchProcedureList({ ...fetchParams, size: procSize }, { filters }, patient, deidentified, groupIds)
+        ? fetchProcedureList(
+            { ...fetchParams, size: procSize },
+            { filters },
+            patient,
+            deidentified,
+            groupIds,
+            undefined,
+            includeRelatedResources
+          )
         : { list: [] }
       // fetchClaimList({ ...fetchParams, size: 1 }, { filters }, patient, deidentified, groupIds)
     ])

--- a/src/types/exploration.ts
+++ b/src/types/exploration.ts
@@ -66,6 +66,13 @@ export enum URLS {
 
 export const GAP = '16px'
 
+// Bounded page size for any PMSI (Condition/Procedure) FHIR search that still
+// requests `_include`: HAPI FHIR rejects a search (HAPI-0389) when too many base
+// resources must be resolved for `_include` in a single query. Distinct from
+// ExplorationBoard's own RESULTS_PER_PAGE (components/ExplorationBoard/useData.ts),
+// which sizes the UI table's page and is unrelated to this guard.
+export const PMSI_INCLUDE_PAGE_SIZE = 500
+
 export type DisplayOptions = {
   myFilters: boolean
   filterBy: boolean

--- a/src/utils/exploration.ts
+++ b/src/utils/exploration.ts
@@ -11,10 +11,17 @@ import {
   Claim,
   Condition,
   Procedure,
-  Bundle
+  Bundle,
+  BundleEntry
 } from 'fhir/r4'
 import { FHIR_Bundle_Promise_Response, FHIR_API_Response } from 'types'
-import { ExplorationResults, FetchOptions, FetchParams, Patient as PatientType } from 'types/exploration'
+import {
+  ExplorationResults,
+  FetchOptions,
+  FetchParams,
+  Patient as PatientType,
+  PMSI_INCLUDE_PAGE_SIZE
+} from 'types/exploration'
 import { getCodeList } from 'services/aphp/serviceValueSets'
 import { getApiResponseResources } from './apiHelpers'
 import {
@@ -109,6 +116,62 @@ type NonPatientResource =
   | MedicationRequest
   | MedicationAdministration
   | DocumentReference
+
+/**
+ * Fetches a FHIR search in bounded `pageSize` chunks (via `_count`/`_offset`) and
+ * concatenates the pages into a single Bundle-shaped response, instead of requesting
+ * `size` results in one shot. Required for any request that also uses `_include`:
+ * HAPI FHIR rejects a search (HAPI-0389) when too many base resources must be
+ * resolved for `_include` in a single query, regardless of how large `size` is.
+ *
+ * When `size` already fits in one page, this issues the exact same single request
+ * as before (no behavior change for existing bounded callers).
+ */
+export const fetchInPages = async <T extends Patient | NonPatientResource>(
+  fetchPage: (size: number, offset: number) => FHIR_Bundle_Promise_Response<T>,
+  size: number,
+  offset = 0,
+  pageSize: number = PMSI_INCLUDE_PAGE_SIZE
+): FHIR_Bundle_Promise_Response<T> => {
+  if (size <= pageSize) {
+    return fetchPage(size, offset)
+  }
+
+  const targetOffset = offset + size
+  let currentOffset = offset
+  let combinedEntries: BundleEntry<T>[] = []
+
+  // `size > pageSize` here, so `targetOffset > offset`: the loop always runs at
+  // least once and `firstResponse` is always assigned before it is read below.
+  const firstPageSize = Math.min(pageSize, targetOffset - currentOffset)
+  const firstResponse = await fetchPage(firstPageSize, currentOffset)
+  if (firstResponse.data.resourceType !== 'Bundle') return firstResponse
+  combinedEntries = combinedEntries.concat(firstResponse.data.entry ?? [])
+  currentOffset += firstPageSize
+
+  // The real total (from the first page) bounds pagination independently of the
+  // originally requested `size`, so a stale/over-estimated total never causes
+  // over-fetching once the actual data is exhausted.
+  const total = firstResponse.data.total ?? combinedEntries.length
+
+  while (currentOffset < targetOffset && currentOffset < total) {
+    const currentSize = Math.min(pageSize, targetOffset - currentOffset)
+    const response = await fetchPage(currentSize, currentOffset)
+
+    if (response.data.resourceType !== 'Bundle') return response
+
+    combinedEntries = combinedEntries.concat(response.data.entry ?? [])
+    currentOffset += currentSize
+  }
+
+  return {
+    ...firstResponse,
+    data: {
+      ...firstResponse.data,
+      entry: combinedEntries
+    }
+  }
+}
 
 export const fetcherWithParams = async <T extends Patient | NonPatientResource, F extends Filters>(
   fetchList: () => FHIR_Bundle_Promise_Response<T>,


### PR DESCRIPTION
## Objectif

https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/issues/3509/

La fiche patient (/patients/:id) plantait avec une erreur 500 pour les patients ayant un historique PMSI
(Condition/Procedure) très volumineux. Le back renvoyait HAPI-0389 : The number of resources in the search request 
is too high to fetch included resources — HAPI refuse la combinaison d'un _count élevé


## Changements réalisés

- fetchLastPmsi ne demande plus _include (jamais exploité sur ce chemin — le lien encounter passe par patient.infos.hospits)
- fetchConditionList/fetchProcedureList : nouveau paramètre includeRelatedResources (défaut true), désactivé uniquement par fetchLastPmsi
- fetchInPages : pagine par blocs de 500 (PMSI_INCLUDE_PAGE_SIZE) pour les appelants qui gardent _include

## Impacts
Front

## Tests réalisés
Unitaires Vitest (nouveaux + suite complète verte), tsc/eslint propres

`patients/6595421d0dd0b05600e1893968317fac56c35fd738d22ef53a659d5a7e3fae40/preview?groupId=20001720`

<img width="1592" height="702" alt="Screenshot From 2026-09-11 16-36-03" src="https://github.com/user-attachments/assets/b90fb9de-ffc8-4052-ade6-c96177e0e1f1" />
<img width="1592" height="702" alt="Screenshot From 2026-09-11 16-35-04" src="https://github.com/user-attachments/assets/1a48d113-3e43-4c35-a2bd-21d969804989" />


## Risques
PMSI_INCLUDE_PAGE_SIZE=500 validé seulement sur l'environnement testé — à surveiller ailleurs